### PR TITLE
ExtraStubs Directory Check

### DIFF
--- a/src/NodeVisitors/SymbolTableIndexer.php
+++ b/src/NodeVisitors/SymbolTableIndexer.php
@@ -43,7 +43,9 @@ class SymbolTableIndexer extends NodeVisitorAbstract {
 				if ($name) {
 					$file = $this->index->getClassFile($name);
 					if ($file) {
-						$this->output->emitError(__CLASS__, $this->filename, $node->getLine(), BaseCheck::TYPE_PARSE_ERROR, "Class $name already exists in $file.");
+						if (!preg_match('/guardrail\/src\/ExtraStubs/', $this->filename)) {
+							$this->output->emitError(__CLASS__, $this->filename, $node->getLine(), BaseCheck::TYPE_PARSE_ERROR, "Class $name already exists in $file.");
+						}
 					} else {
 						$this->index->addClass($name, $node, $this->filename);
 					}

--- a/src/Phases/AnalyzingPhase.php
+++ b/src/Phases/AnalyzingPhase.php
@@ -185,7 +185,7 @@ class AnalyzingPhase
 		$configArray = $config->getConfigArray();
 		foreach($configArray['test'] as $directory) {
 			$directory=$basePath."/".$directory;
-			$output->outputVerbose("Directory: $directory\n");
+			$output->outputVerbose("\n\nDirectory: $directory\n");
 			$it = new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS);
 	 		$it2 = new \RecursiveIteratorIterator($it);
 			$this->getPhase2Files($config, $output, $it2, $toProcess);
@@ -200,7 +200,7 @@ class AnalyzingPhase
 			: array_slice($toProcess, $groupSize * ($config->getPartitionNumber()-1), $groupSize);
 
 
-		$output->outputVerbose("Analyzing ".count($toProcess)." files\n");
+		$output->outputVerbose("\n\nAnalyzing ".count($toProcess)." files\n");
 
 		if($config->getProcessCount()>1) {
 			return $this->runChildProcesses($config, $output, $toProcess);

--- a/src/Phases/IndexingPhase.php
+++ b/src/Phases/IndexingPhase.php
@@ -75,7 +75,7 @@ class IndexingPhase
 	}
 
 	function indexTraitClasses(SymbolTable $symbolTable, OutputInterface $output) {
-		$output->outputVerbose("Importing traits\n");
+		$output->outputVerbose("\n\nImporting traits\n");
 		$count = 0;
 		foreach($symbolTable->getClassesThatUseATrait() as $className) {
 			$class = $symbolTable->getClass($className);
@@ -90,8 +90,8 @@ class IndexingPhase
 		$indexPaths = $configArr['index'];
 
 		foreach ($indexPaths as $directory) {
-			$tmpDirectory = strpos($directory, "/") === 0 ? $directory : $config->getBasePath() . "/" . $directory;
-			$output->outputVerbose("Indexing Directory: " . $tmpDirectory . "\n");
+			$tmpDirectory = strpos($directory, "/") === 0 ? $directory : $config->getBasePath() . $directory;
+			$output->outputVerbose("\n\nIndexing Directory: " . $tmpDirectory . "\n");
 			$it = new \RecursiveDirectoryIterator($tmpDirectory, \FilesystemIterator::SKIP_DOTS);
 			$it2 = new \RecursiveIteratorIterator($it);
 			$this->index($config, $output, $it2);


### PR DESCRIPTION
- if we get duplicate errors in the ExtraStubs directory when indexing,
just skip them
- additional small formatting issues for directories we are indexing
and additional spacing for better output