### PR TITLE
BackTickCheck Tests

### DIFF
--- a/src/Checks/BackTickOperatorCheck.php
+++ b/src/Checks/BackTickOperatorCheck.php
@@ -1,20 +1,29 @@
-<?php
+<?php namespace BambooHR\Guardrail\Checks;
 
 /**
  * Guardrail.  Copyright (c) 2016-2017, Jonathan Gardiner and BambooHR.
  * Apache 2.0 License
  */
 
-namespace BambooHR\Guardrail\Checks;
-
 use PhpParser\Node;
+use PhpParser\Node\Expr\ShellExec;
 use PhpParser\Node\Stmt\ClassLike;
 use BambooHR\Guardrail\Scope;
 
-class BacktickOperatorCheck extends BaseCheck
-{
-	function getCheckNodeTypes() {
-		return [\PhpParser\Node\Expr\ShellExec::class];
+/**
+ * Class BackTickOperatorCheck
+ *
+ * @package BambooHR\Guardrail\Checks
+ */
+class BackTickOperatorCheck extends BaseCheck {
+
+	/**
+	 * getCheckNodeTypes
+	 *
+	 * @return string[]
+	 */
+	public function getCheckNodeTypes() {
+		return [ShellExec::class];
 	}
 
 	/**
@@ -25,10 +34,12 @@ class BacktickOperatorCheck extends BaseCheck
 	 * @param ClassLike|null $inside   Instance of the ClassLike (the class we are parsing) [optional]
 	 * @param Scope|null     $scope    Instance of the Scope (all variables in the current state) [optional]
 	 *
-	 * @return mixed
+	 * @return void
 	 */
 	public function run($fileName, Node $node, ClassLike $inside=null, Scope $scope=null) {
 		$this->incTests();
-		$this->emitError($fileName,$node,ErrorConstants::TYPE_SECURITY_BACKTICK, "Unsafe operator (backtick)");
+		if ($node instanceof ShellExec) {
+			$this->emitError($fileName,$node,ErrorConstants::TYPE_SECURITY_BACKTICK, "Unsafe operator (back tick)");
+		}
 	}
 }

--- a/src/Checks/BaseCheck.php
+++ b/src/Checks/BaseCheck.php
@@ -42,6 +42,8 @@ abstract class BaseCheck extends ErrorConstants {
 	}
 
 	/**
+	 * getCheckNodeTypes
+	 *
 	 * @return string[]
 	 */
 	abstract function getCheckNodeTypes();
@@ -54,7 +56,7 @@ abstract class BaseCheck extends ErrorConstants {
 	 * @param ClassLike|null $inside   Instance of the ClassLike (the class we are parsing) [optional]
 	 * @param Scope|null     $scope    Instance of the Scope (all variables in the current state) [optional]
 	 *
-	 * @return mixed
+	 * @return void
 	 */
 	abstract public function run($fileName, Node $node, ClassLike $inside = null, Scope $scope = null);
 }

--- a/tests/units/Checks/TestBackTickOperatorCheck.php
+++ b/tests/units/Checks/TestBackTickOperatorCheck.php
@@ -1,0 +1,34 @@
+<?php namespace BambooHR\Guardrail\Tests\Checks;
+
+use BambooHR\Guardrail\Checks\BacktickOperatorCheck;
+use BambooHR\Guardrail\Tests\TestSuiteSetup;
+
+/**
+ * Class TestBackTickOperatorCheck
+ *
+ * @package BambooHR\Guardrail\Tests\Checks
+ */
+class TestBackTickOperatorCheck extends TestSuiteSetup {
+
+	/**
+	 * testBackTicksThrowError
+	 *
+	 * @return void
+	 */
+	public function testBackTicksThrowError() {
+		$code = '<?php echo `ping -n 3 {$host}`;';
+		$statements = $this->parseText($code);
+		$this->checkClassEmitsErrorOnce(BacktickOperatorCheck::class, $statements[0]->exprs[0]);
+	}
+
+	/**
+	 * testBackTicksNotThrownInComment
+	 *
+	 * @return void
+	 */
+	public function testBackTicksNotThrownInComment() {
+		$code = '<?php //`ping -n 3 {$host}`';
+		$statements = $this->parseText($code);
+		$this->checkClassNeverEmitsError(BacktickOperatorCheck::class, $statements[0]);
+	}
+}


### PR DESCRIPTION
- adding unit tests for BackTickChecks
- minor cleanup on the BackTickChecks class to make sure the node IS an
instance of ShellExec before emitting the error