### PR TITLE
Global time zone checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Standard.Unknown.Global.Constant | Reference to an undefined global constant (de
 Standard.Unknown.Property | Reference to a property that has not previously been declared
 Standard.Unknown.Variable | Reference to a variable that has not previously been assigned
 Standard.Unused.Variable | A local variable is assigned but never read from.
+Standard.Unsafe.Timezone | Functions, such as date() that use a server setting for timezone instead of explicitly passing the timezone.
 Standard.VariableFunctionCall | Call a method $foo() when $foo is a string.  (Still ok if $foo is a callable)
 Standard.VariableVariable | Referencing a variable with $$var
 

--- a/src/Checks/ErrorConstants.php
+++ b/src/Checks/ErrorConstants.php
@@ -44,6 +44,7 @@ class ErrorConstants {
 	const TYPE_UNKNOWN_PROPERTY = 'Standard.Unknown.Property';
 	const TYPE_UNKNOWN_VARIABLE = 'Standard.Unknown.Variable';
 	const TYPE_UNREACHABLE_CODE = 'Standard.Unreachable';
+	const TYPE_UNSAFE_TIME_ZONE = "Standard.Unsafe.TimeZone";
 	const TYPE_UNUSED_VARIABLE = 'Standard.Unused.Variable';
 	const TYPE_VARIABLE_FUNCTION_NAME = 'Standard.VariableFunctionCall';
 	const TYPE_VARIABLE_VARIABLE = 'Standard.VariableVariable';

--- a/src/Checks/FunctionCallCheck.php
+++ b/src/Checks/FunctionCallCheck.php
@@ -132,6 +132,7 @@ class FunctionCallCheck extends BaseCheck {
 	 * @param string   $fileName The file being scanned
 	 * @param FuncCall $node     The AST node
 	 * @param string   $name     The name of the function being called
+	 * @return void
 	 */
 	protected function checkForDateWithoutTimeZone($fileName, FuncCall $node, $name) {
 		// Safe code does not depend on .ini settings.  If you use date(), you are tied to the local time zone.

--- a/src/Checks/FunctionCallCheck.php
+++ b/src/Checks/FunctionCallCheck.php
@@ -128,14 +128,19 @@ class FunctionCallCheck extends BaseCheck {
 		}
 	}
 
+	/**
+	 * @param string   $fileName The file being scanned
+	 * @param FuncCall $node     The AST node
+	 * @param string   $name     The name of the function being called
+	 */
 	protected function checkForDateWithoutTimeZone($fileName, FuncCall $node, $name) {
 		// Safe code does not depend on .ini settings.  If you use date(), you are tied to the local time zone.
-		if (strcasecmp(strval($node->name), "date") == 0) {
+		if (strcasecmp($name, "date") == 0) {
 			$this->emitError($fileName, $node, ErrorConstants::TYPE_UNSAFE_TIME_ZONE, "The date() function always uses the local time zone.");
 		}
 
 		if (
-			(strcasecmp(strval($node->name),"date_create") == 0 || strcasecmp(strval($node->name),"date_create_immutable") == 0) &&
+			(strcasecmp($name, "date_create") == 0 || strcasecmp($name, "date_create_immutable") == 0) &&
 			count($node->args) < 2
 		) {
 			$this->emitError($fileName, $node, ErrorConstants::TYPE_UNSAFE_TIME_ZONE, "Calling the date_create() function without a timezone uses the local time zone.");

--- a/src/Checks/FunctionCallCheck.php
+++ b/src/Checks/FunctionCallCheck.php
@@ -70,6 +70,7 @@ class FunctionCallCheck extends BaseCheck {
 					$this->emitError($fileName, $node, ErrorConstants::TYPE_SECURITY_DANGEROUS, "Call to dangerous function $name()");
 				}
 				$this->checkForDebugMethods($fileName, $node, $name);
+				$this->checkForDateWithoutTimeZone($fileName, $node, $name);
 
 				$func = $this->symbolTable->getAbstractedFunction($name);
 				if ($func) {
@@ -124,6 +125,20 @@ class FunctionCallCheck extends BaseCheck {
 		$toLower = strtolower($name);
 		if (array_key_exists($toLower, self::$debug)) {
 			$this->emitError($fileName, $node, ErrorConstants::TYPE_DEBUG, "Call to common debug function $name() detected");
+		}
+	}
+
+	protected function checkForDateWithoutTimeZone($fileName, FuncCall $node, $name) {
+		// Safe code does not depend on .ini settings.  If you use date(), you are tied to the local time zone.
+		if (strcasecmp(strval($node->name), "date") == 0) {
+			$this->emitError($fileName, $node, ErrorConstants::TYPE_UNSAFE_TIME_ZONE, "The date() function always uses the local time zone.");
+		}
+
+		if (
+			(strcasecmp(strval($node->name),"date_create") == 0 || strcasecmp(strval($node->name),"date_create_immutable") == 0) &&
+			count($node->args) < 2
+		) {
+			$this->emitError($fileName, $node, ErrorConstants::TYPE_UNSAFE_TIME_ZONE, "Calling the date_create() function without a timezone uses the local time zone.");
 		}
 	}
 }

--- a/src/Checks/InstantiationCheck.php
+++ b/src/Checks/InstantiationCheck.php
@@ -54,6 +54,10 @@ class InstantiationCheck extends BaseCheck {
 						return;
 					}
 
+					$this->checkDateTimeWithoutTimeZone($fileName, $node, $class);
+
+
+
 					$method = Util::findAbstractedMethod($name, "__construct", $this->symbolTable);
 
 					if (!$method) {
@@ -80,6 +84,16 @@ class InstantiationCheck extends BaseCheck {
 					}
 				}
 			}
+		}
+	}
+
+	protected function checkDateTimeWithoutTimeZone($fileName, New_ $node, $className) {
+
+		if (
+			(strcasecmp($className,"datetime") == 0 || strcasecmp($className,"datetimeimmutable") == 0) &&
+			count($node->args)<2
+		) {
+			$this->emitError($fileName, $node, ErrorConstants::TYPE_UNSAFE_TIMEZONE, "Instantiating a DateTime or DateTimeImmutable without a timezone uses local time.")
 		}
 	}
 }

--- a/src/Checks/InstantiationCheck.php
+++ b/src/Checks/InstantiationCheck.php
@@ -89,6 +89,7 @@ class InstantiationCheck extends BaseCheck {
 	 * @param string $fileName  The file being scanned
 	 * @param New_   $node      The instantiation AST node
 	 * @param string $className The name of the class being instantiated.
+	 * @return void
 	 */
 	protected function checkDateTimeWithoutTimeZone($fileName, New_ $node, $className) {
 

--- a/src/Checks/InstantiationCheck.php
+++ b/src/Checks/InstantiationCheck.php
@@ -93,7 +93,7 @@ class InstantiationCheck extends BaseCheck {
 			(strcasecmp($className,"datetime") == 0 || strcasecmp($className,"datetimeimmutable") == 0) &&
 			count($node->args)<2
 		) {
-			$this->emitError($fileName, $node, ErrorConstants::TYPE_UNSAFE_TIMEZONE, "Instantiating a DateTime or DateTimeImmutable without a timezone uses local time.")
+			$this->emitError($fileName, $node, ErrorConstants::TYPE_UNSAFE_TIME_ZONE, "Instantiating a DateTime or DateTimeImmutable without a timezone uses local time.");
 		}
 	}
 }

--- a/src/Checks/InstantiationCheck.php
+++ b/src/Checks/InstantiationCheck.php
@@ -54,9 +54,7 @@ class InstantiationCheck extends BaseCheck {
 						return;
 					}
 
-					$this->checkDateTimeWithoutTimeZone($fileName, $node, $class);
-
-
+					$this->checkDateTimeWithoutTimeZone($fileName, $node, $name);
 
 					$method = Util::findAbstractedMethod($name, "__construct", $this->symbolTable);
 
@@ -87,11 +85,16 @@ class InstantiationCheck extends BaseCheck {
 		}
 	}
 
+	/**
+	 * @param string $fileName  The file being scanned
+	 * @param New_   $node      The instantiation AST node
+	 * @param string $className The name of the class being instantiated.
+	 */
 	protected function checkDateTimeWithoutTimeZone($fileName, New_ $node, $className) {
 
 		if (
-			(strcasecmp($className,"datetime") == 0 || strcasecmp($className,"datetimeimmutable") == 0) &&
-			count($node->args)<2
+			(strcasecmp($className, "datetime") == 0 || strcasecmp($className, "datetimeimmutable") == 0) &&
+			count($node->args) < 2
 		) {
 			$this->emitError($fileName, $node, ErrorConstants::TYPE_UNSAFE_TIME_ZONE, "Instantiating a DateTime or DateTimeImmutable without a timezone uses local time.");
 		}

--- a/tests/units/Checks/TestData/TestFunctionCallCheck.7.inc
+++ b/tests/units/Checks/TestData/TestFunctionCallCheck.7.inc
@@ -1,0 +1,12 @@
+<?php
+
+// Unsafe
+$today = date("Y-m-d");
+
+// Unsafe
+$todayDateTime = date_create("now");
+
+$todayDateTimeImmutable = date_create_immutable("now");
+
+// Safe
+$gmToday = gmdate("Y-m-d");

--- a/tests/units/Checks/TestData/TestInstantiationCheck.1.inc
+++ b/tests/units/Checks/TestData/TestInstantiationCheck.1.inc
@@ -1,0 +1,19 @@
+<?php
+
+
+// Unsafe
+$time = new DateTime();
+
+// Unsafe
+$time2 = new DateTime("now");
+
+// Unsafe
+$timeImmutable = new DateTimeImmutable();
+
+// Unsafe
+$timeImmutable2 = new DateTimeImmutable($time);
+
+
+// Safe
+$time = new DateTime("now", new DateTimeZone("America/Denver"));
+

--- a/tests/units/Checks/TestFunctionCallCheck.php
+++ b/tests/units/Checks/TestFunctionCallCheck.php
@@ -51,6 +51,8 @@ class TestFunctionCallCheck extends TestSuiteSetup {
 		$this->assertEquals(3, $this->runAnalyzerOnFile('.4.inc', ErrorConstants::TYPE_DEPRECATED_USER));
 	}
 
+
+
 	/**
 	 * testUnknownFunctionCall
 	 *
@@ -68,5 +70,13 @@ class TestFunctionCallCheck extends TestSuiteSetup {
 	 */
 	public function testVariableFunctionName() {
 		$this->assertEquals(1, $this->runAnalyzerOnFile('.6.inc', ErrorConstants::TYPE_VARIABLE_FUNCTION_NAME));
+	}
+
+	/**
+	 *
+	 * @return void
+	 */
+	public function testTimeZones() {
+		$this->assertEquals(3, $this->runAnalyzerOnFile('.7.inc', ErrorConstants::TYPE_UNSAFE_TIME_ZONE));
 	}
 }

--- a/tests/units/Checks/TestInstantiationCheck.php
+++ b/tests/units/Checks/TestInstantiationCheck.php
@@ -1,0 +1,21 @@
+<?php namespace BambooHR\Guardrail\Tests\Checks;
+
+use BambooHR\Guardrail\Checks\ErrorConstants;
+use BambooHR\Guardrail\Tests\TestSuiteSetup;
+
+
+/**
+ * Class TestFunctionCalCheck
+ *
+ * @package BambooHR\Guardrail\Tests\Checks
+ */
+class TestInstantionCheck extends TestSuiteSetup {
+
+	/**
+	 *
+	 * @return void
+	 */
+	public function testUnsafeTimeZones() {
+		$this->assertEquals(4, $this->runAnalyzerOnFile('.1.inc',ErrorConstants::TYPE_UNSAFE_TIME_ZONE));
+	}
+}


### PR DESCRIPTION
Having a global variable for time zone is dangerous.  Lets help point out a few cases where we're using the default time zone instead of explicitly passing it.