### PR TITLE
Fix an issue where private methods in the child and parent are causing a Standard.Param.Type issue where it shouldn't.

### DIFF
--- a/src/Checks/InterfaceCheck.php
+++ b/src/Checks/InterfaceCheck.php
@@ -53,10 +53,8 @@ class InterfaceCheck extends BaseCheck {
 
 		$className = (isset($class->namespacedName) ? strval($class->namespacedName) : "anonymous class");
 
-		// "public" and "protected" can be redefined," private can not.
-		if (
-			$oldVisibility != $visibility && $oldVisibility == "private"
-		) {
+		// "public" and "protected" cannot be redefined, but private can.
+		if ($oldVisibility !== $visibility && $oldVisibility !== "private") {
 			$this->emitError($fileName, $class, self::TYPE_SIGNATURE_TYPE, "Access level mismatch in " . $method->getName() . "() " . $visibility . " vs " . $oldVisibility);
 		}
 
@@ -74,9 +72,9 @@ class InterfaceCheck extends BaseCheck {
 					$parentParam = $parentMethodParams[$index];
 					$name1 = strval($param->getType());
 					$name2 = strval($parentParam->getType());
-					if (
-						$visibility !== 'private' && $oldVisibility !== 'private' && strcasecmp($name1, $name2) !== 0
-					) {
+					if ($oldVisibility !== 'private' && strcasecmp($name1, $name2) !== 0) {
+						$name1 = empty($name1) ? '(no parameter)' : $name1;
+						$name2 = empty($name2) ? '(no parameter)' : $name2;
 						$this->emitErrorOnLine($fileName, $method->getStartingLine(), self::TYPE_SIGNATURE_TYPE, "Parameter mismatch type mismatch " . $className . "::" . $method->getName() . " : $name1 vs $name2");
 						break;
 					}

--- a/src/Checks/InterfaceCheck.php
+++ b/src/Checks/InterfaceCheck.php
@@ -75,7 +75,7 @@ class InterfaceCheck extends BaseCheck {
 					$name1 = strval($param->getType());
 					$name2 = strval($parentParam->getType());
 					if (
-						strcasecmp($name1, $name2) !== 0
+						$visibility !== 'private' && $oldVisibility !== 'private' && strcasecmp($name1, $name2) !== 0
 					) {
 						$this->emitErrorOnLine($fileName, $method->getStartingLine(), self::TYPE_SIGNATURE_TYPE, "Parameter mismatch type mismatch " . $className . "::" . $method->getName() . " : $name1 vs $name2");
 						break;

--- a/src/Checks/InterfaceCheck.php
+++ b/src/Checks/InterfaceCheck.php
@@ -22,6 +22,16 @@ use BambooHR\Guardrail\Abstractions\ClassAbstraction as AbstractedClass_;
  * @package BambooHR\Guardrail\Checks
  */
 class InterfaceCheck extends BaseCheck {
+	/**
+	 * Visibility level map
+	 *
+	 * @var array
+	 */
+	static private $methodVisibilityLevels = [
+		'private' => 0,
+		'protected' => 1,
+		'public' => 2,
+	];
 
 	/**
 	 * getCheckNodeTypes
@@ -54,7 +64,7 @@ class InterfaceCheck extends BaseCheck {
 		$className = (isset($class->namespacedName) ? strval($class->namespacedName) : "anonymous class");
 
 		// "public" and "protected" cannot be redefined, but private can.
-		if ($oldVisibility !== $visibility && $oldVisibility !== "private") {
+		if (self::$methodVisibilityLevels[$visibility] < self::$methodVisibilityLevels[$oldVisibility]) {
 			$this->emitError($fileName, $class, self::TYPE_SIGNATURE_TYPE, "Access level mismatch in " . $method->getName() . "() " . $visibility . " vs " . $oldVisibility);
 		}
 

--- a/tests/units/Checks/TestData/TestInterfaceCheck.1.inc
+++ b/tests/units/Checks/TestData/TestInterfaceCheck.1.inc
@@ -1,0 +1,17 @@
+<?php
+
+class PrivateSomeClass {
+
+}
+
+class PrivateParentClass {
+	private function testMethod($item) {
+		return;
+	}
+}
+
+class PrivateChildClass extends PrivateParentClass {
+	private function testMethod(PrivateSomeClass $item1, PrivateSomeClass $item2 = null) {
+		return;
+	}
+}

--- a/tests/units/Checks/TestData/TestInterfaceCheck.2.inc
+++ b/tests/units/Checks/TestData/TestInterfaceCheck.2.inc
@@ -1,0 +1,17 @@
+<?php
+
+class ProtectedSomeClass {
+
+}
+
+class ProtectedParentClass {
+	protected function testMethod($item) {
+		return;
+	}
+}
+
+class ProtectedChildClass extends ProtectedParentClass {
+	protected function testMethod(ProtectedSomeClass $item1, ProtectedSomeClass $item2 = null) {
+		return;
+	}
+}

--- a/tests/units/Checks/TestData/TestInterfaceCheck.3.inc
+++ b/tests/units/Checks/TestData/TestInterfaceCheck.3.inc
@@ -1,0 +1,17 @@
+<?php
+
+class PublicSomeClass {
+
+}
+
+class PublicParentClass {
+	public function testMethod($item) {
+		return;
+	}
+}
+
+class PublicChildClass extends PublicParentClass {
+	public function testMethod(PublicSomeClass $item1, ProtectedSomeClass $item2 = null) {
+		return;
+	}
+}

--- a/tests/units/Checks/TestData/TestInterfaceCheck.3.inc
+++ b/tests/units/Checks/TestData/TestInterfaceCheck.3.inc
@@ -11,7 +11,7 @@ class PublicParentClass {
 }
 
 class PublicChildClass extends PublicParentClass {
-	public function testMethod(PublicSomeClass $item1, ProtectedSomeClass $item2 = null) {
+	public function testMethod(PublicSomeClass $item1, PublicSomeClass $item2 = null) {
 		return;
 	}
 }

--- a/tests/units/Checks/TestData/TestInterfaceCheck.4.inc
+++ b/tests/units/Checks/TestData/TestInterfaceCheck.4.inc
@@ -1,0 +1,17 @@
+<?php
+
+class AnotherTestClass {
+
+}
+
+class PrivateParentClassCheck4 {
+	private function testMethod($item) {
+		return;
+	}
+}
+
+class PublicChildClassCheck4 extends PrivateParentClassCheck4 {
+	public function testMethod(AnotherTestClass $item1, AnotherTestClass $item2 = null) {
+		return;
+	}
+}

--- a/tests/units/Checks/TestData/TestInterfaceCheck.5.inc
+++ b/tests/units/Checks/TestData/TestInterfaceCheck.5.inc
@@ -1,0 +1,17 @@
+<?php
+
+class AnotherTestClass5 {
+
+}
+
+class PublicParentClassCheck5 {
+	public function testMethod($item) {
+		return;
+	}
+}
+
+class PrivateChildClassCheck5 extends PublicParentClassCheck5 {
+	private function testMethod(AnotherTestClass5 $item1, AnotherTestClass5 $item2 = null) {
+		return;
+	}
+}

--- a/tests/units/Checks/TestData/TestInterfaceCheck.6.inc
+++ b/tests/units/Checks/TestData/TestInterfaceCheck.6.inc
@@ -1,0 +1,19 @@
+<?php
+
+class PrivateParentClassCheck6 {
+	private function testMethod() {
+		return;
+	}
+}
+
+class ProtectedParentClassCheck6 extends PrivateParentClassCheck6 {
+	protected function testMethod() {
+		return;
+	}
+}
+
+class PublicChildClassCheck6 extends ProtectedParentClassCheck6 {
+	public function testMethod() {
+		return;
+	}
+}

--- a/tests/units/Checks/TestInterfaceCheck.php
+++ b/tests/units/Checks/TestInterfaceCheck.php
@@ -60,4 +60,14 @@ class TestInterfaceCheck extends TestSuiteSetup {
 	public function testPrivateChildPublicParentMethodWithDifferentSignaturesInheritance() {
 		$this->assertEquals(2, $this->runAnalyzerOnFile('.5.inc', ErrorConstants::TYPE_SIGNATURE_TYPE));
 	}
+
+	/**
+	 * Test 3 levels of inheritance where each child gets more visible than the parent. Parent => private, child1 => protected, child2 => public
+	 * and it is valid to do so as long as the signature stays the same.
+	 *
+	 * @return void
+	 */
+	public function testSameSignatureDifferentVisibilityValid() {
+		$this->assertEquals(0, $this->runAnalyzerOnFile('.6.inc', ErrorConstants::TYPE_SIGNATURE_TYPE));
+	}
 }

--- a/tests/units/Checks/TestInterfaceCheck.php
+++ b/tests/units/Checks/TestInterfaceCheck.php
@@ -40,4 +40,24 @@ class TestInterfaceCheck extends TestSuiteSetup {
 	public function testPublicMethodsWithDifferentSignaturesInheritance() {
 		$this->assertEquals(1, $this->runAnalyzerOnFile('.3.inc', ErrorConstants::TYPE_SIGNATURE_TYPE));
 	}
+
+	/**
+	 * Test a parent/child inheritance scheme where the child has a public method and the parent has a private method. The methods have
+	 * different signatures. This is valid because the parent is private.
+	 *
+	 * @return void
+	 */
+	public function testPublicChildPrivateParentMethodWithDifferentSignaturesInheritance() {
+		$this->assertEquals(0, $this->runAnalyzerOnFile('.4.inc', ErrorConstants::TYPE_SIGNATURE_TYPE));
+	}
+
+	/**
+	 * Test a parent/child inheritance scheme where the child has a private method and the parent has a public method. The methods have
+	 * different signatures. This is invalid because the parent is private but also because the parameters mismatch. Thus we should see 2 errors.
+	 *
+	 * @return void
+	 */
+	public function testPrivateChildPublicParentMethodWithDifferentSignaturesInheritance() {
+		$this->assertEquals(2, $this->runAnalyzerOnFile('.5.inc', ErrorConstants::TYPE_SIGNATURE_TYPE));
+	}
 }

--- a/tests/units/Checks/TestInterfaceCheck.php
+++ b/tests/units/Checks/TestInterfaceCheck.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace BambooHR\Guardrail\Tests\Checks;
+
+use BambooHR\Guardrail\Checks\ErrorConstants;
+use BambooHR\Guardrail\Tests\TestSuiteSetup;
+
+/**
+ * Class TestInterfaceCheck
+ *
+ * @package BambooHR\Guardrail\Tests\Checks
+ */
+class TestInterfaceCheck extends TestSuiteSetup {
+	/**
+	 * Test a parent/child inheritance scheme where the child and parent both have a private method with the same name but
+	 * different signatures. This is valid.
+	 *
+	 * @return void
+	 */
+	public function testPrivateMethodsWithDifferentSignaturesInheritance() {
+		$this->assertEquals(0, $this->runAnalyzerOnFile('.1.inc', ErrorConstants::TYPE_SIGNATURE_TYPE));
+	}
+
+	/**
+	 * Test a parent/child inheritance scheme where the child and parent both have a protected method with the same name but
+	 * different signatures. This is invalid.
+	 *
+	 * @return void
+	 */
+	public function testProtectedMethodsWithDifferentSignaturesInheritance() {
+		$this->assertEquals(1, $this->runAnalyzerOnFile('.2.inc', ErrorConstants::TYPE_SIGNATURE_TYPE));
+	}
+
+	/**
+	 * Test a parent/child inheritance scheme where the child and parent both have a public method with the same name but
+	 * different signatures. This is invalid.
+	 *
+	 * @return void
+	 */
+	public function testPublicMethodsWithDifferentSignaturesInheritance() {
+		$this->assertEquals(1, $this->runAnalyzerOnFile('.3.inc', ErrorConstants::TYPE_SIGNATURE_TYPE));
+	}
+}


### PR DESCRIPTION
When a child implements a private method with the same name but a different signature this should be valid because PHP allows it. This commit fixes that issue by ensuring that the parent and child class's implementations of the method are both private before doing the parameter mismatch check.