### PR TITLE
[GM-2363] Unused Private Variables Check

### DIFF
--- a/src/Checks/ErrorConstants.php
+++ b/src/Checks/ErrorConstants.php
@@ -52,6 +52,7 @@ class ErrorConstants {
 	const TYPE_UNREACHABLE_CODE = 'Standard.Unreachable';
 	const TYPE_UNSAFE_TIME_ZONE = "Standard.Unsafe.TimeZone";
 	const TYPE_UNUSED_VARIABLE = 'Standard.Unused.Variable';
+	const TYPE_UNUSED_PROPERTY = 'Standard.Unused.Property';
 	const TYPE_VARIABLE_FUNCTION_NAME = 'Standard.VariableFunctionCall';
 	const TYPE_VARIABLE_VARIABLE = 'Standard.VariableVariable';
 

--- a/src/Checks/UnusedPrivateMemberVariableCheck.php
+++ b/src/Checks/UnusedPrivateMemberVariableCheck.php
@@ -1,0 +1,57 @@
+<?php namespace BambooHR\Guardrail\Checks;
+
+use BambooHR\Guardrail\NodeVisitors\ForEachNode;
+use BambooHR\Guardrail\Scope;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\Property;
+
+/**
+ * Class UnusedPrivateMemberVariableCheck
+ * @package BambooHR\Guardrail\Checks
+ */
+class UnusedPrivateMemberVariableCheck extends BaseCheck {
+
+	/**
+	 * getCheckNodeTypes
+	 *
+	 * @return string[]
+	 */
+	function getCheckNodeTypes() {
+		return [Property::class];
+	}
+
+	/**
+	 * run
+	 *
+	 * @param string         $fileName The name of the file we are parsing
+	 * @param Node           $node     Instance of the Node
+	 * @param ClassLike|null $inside   Instance of the ClassLike (the class we are parsing) [optional]
+	 * @param Scope|null     $scope    Instance of the Scope (all variables in the current state) [optional]
+	 *
+	 * @return void
+	 */
+	public function run($fileName, Node $node, ClassLike $inside = null, Scope $scope = null) {
+		if ($node instanceof Property && $node->isPrivate()) {
+			$memberVariable = $node->props[0]->name;
+			$usedVariables = [];
+			if ($inside instanceof Class_) {
+				foreach ($inside->stmts as $statement) {
+					// we will ignore constructors for the purposes of usage
+					if ($statement instanceof Node\Stmt\ClassMethod && $statement->name !== '__construct') {
+						$getVar = function ($object) use (&$usedVariables) {
+							if ($object instanceof Node\Expr\PropertyFetch) {
+								$usedVariables[] = $object->name;
+							}
+						};
+						ForEachNode::run($statement->getStmts(), $getVar);
+					}
+				}
+			}
+			if (!in_array($memberVariable, $usedVariables)) {
+				$this->emitError($fileName, $node, ErrorConstants::TYPE_UNUSED_VARIABLE, "Unused private variable detected");
+			}
+		}
+	}
+}

--- a/src/Checks/UnusedPrivateMemberVariableCheck.php
+++ b/src/Checks/UnusedPrivateMemberVariableCheck.php
@@ -41,12 +41,11 @@ class UnusedPrivateMemberVariableCheck extends BaseCheck {
 				foreach ($inside->stmts as $statement) {
 					// we will ignore constructors for the purposes of usage
 					if ($statement instanceof Node\Stmt\ClassMethod && $statement->name !== '__construct') {
-						$getVar = function ($object) use (&$usedVariables) {
+						ForEachNode::run($statement->getStmts(), function ($object) use (&$usedVariables) {
 							if ($object instanceof Node\Expr\PropertyFetch) {
 								$usedVariables[] = $object->name;
 							}
-						};
-						ForEachNode::run($statement->getStmts(), $getVar);
+						});
 					}
 				}
 			}

--- a/src/Checks/UnusedPrivateMemberVariableCheck.php
+++ b/src/Checks/UnusedPrivateMemberVariableCheck.php
@@ -34,7 +34,7 @@ class UnusedPrivateMemberVariableCheck extends BaseCheck {
 	 */
 	public function run($fileName, Node $node, ClassLike $inside = null, Scope $scope = null) {
 		$memberVariables = [];
-		if ($node instanceof Property && $node->isPrivate()) {
+		if ($node instanceof Property && $node->type == Class_::MODIFIER_PRIVATE) {
 			$memberVariables[] = $node->props[0]->name;
 			$usedVariables = [];
 			if ($inside instanceof Class_) {
@@ -60,7 +60,7 @@ class UnusedPrivateMemberVariableCheck extends BaseCheck {
 		foreach ($inside->stmts as $statement) {
 			// we will ignore constructors for the purposes of usage
 			if ($statement instanceof Node\Stmt\ClassMethod && $statement->name !== '__construct') {
-				ForEachNode::run($statement->getStmts(), function ($object) use (&$usedVariables) {
+				ForEachNode::run($statement->stmts, function ($object) use (&$usedVariables) {
 					if ($object instanceof Node\Expr\PropertyFetch) {
 						$usedVariables[] = $object->name;
 					}

--- a/src/Checks/UnusedPrivateMemberVariableCheck.php
+++ b/src/Checks/UnusedPrivateMemberVariableCheck.php
@@ -33,8 +33,9 @@ class UnusedPrivateMemberVariableCheck extends BaseCheck {
 	 * @return void
 	 */
 	public function run($fileName, Node $node, ClassLike $inside = null, Scope $scope = null) {
+		$memberVariables = [];
 		if ($node instanceof Property && $node->isPrivate()) {
-			$memberVariable = $node->props[0]->name;
+			$memberVariables[] = $node->props[0]->name;
 			$usedVariables = [];
 			if ($inside instanceof Class_) {
 				foreach ($inside->stmts as $statement) {
@@ -49,8 +50,10 @@ class UnusedPrivateMemberVariableCheck extends BaseCheck {
 					}
 				}
 			}
-			if (!in_array($memberVariable, $usedVariables)) {
-				$this->emitError($fileName, $node, ErrorConstants::TYPE_UNUSED_VARIABLE, "Unused private variable detected");
+			foreach ($memberVariables as $memberVariable) {
+				if (!in_array($memberVariable, $usedVariables)) {
+					$this->emitError($fileName, $node, ErrorConstants::TYPE_UNUSED_PROPERTY, "Unused private variable detected");
+				}
 			}
 		}
 	}

--- a/src/Checks/UnusedPrivateMemberVariableCheck.php
+++ b/src/Checks/UnusedPrivateMemberVariableCheck.php
@@ -38,16 +38,7 @@ class UnusedPrivateMemberVariableCheck extends BaseCheck {
 			$memberVariables[] = $node->props[0]->name;
 			$usedVariables = [];
 			if ($inside instanceof Class_) {
-				foreach ($inside->stmts as $statement) {
-					// we will ignore constructors for the purposes of usage
-					if ($statement instanceof Node\Stmt\ClassMethod && $statement->name !== '__construct') {
-						ForEachNode::run($statement->getStmts(), function ($object) use (&$usedVariables) {
-							if ($object instanceof Node\Expr\PropertyFetch) {
-								$usedVariables[] = $object->name;
-							}
-						});
-					}
-				}
+				$usedVariables = $this->checkInside($inside);
 			}
 			foreach ($memberVariables as $memberVariable) {
 				if (!in_array($memberVariable, $usedVariables)) {
@@ -55,5 +46,27 @@ class UnusedPrivateMemberVariableCheck extends BaseCheck {
 				}
 			}
 		}
+	}
+
+	/**
+	 * checkInside
+	 *
+	 * @param ClassLike|null $inside Instance of the ClassLike (the class we are parsing)
+	 *
+	 * @return array
+	 */
+	protected function checkInside(ClassLike $inside) {
+		$usedVariables = [];
+		foreach ($inside->stmts as $statement) {
+			// we will ignore constructors for the purposes of usage
+			if ($statement instanceof Node\Stmt\ClassMethod && $statement->name !== '__construct') {
+				ForEachNode::run($statement->getStmts(), function ($object) use (&$usedVariables) {
+					if ($object instanceof Node\Expr\PropertyFetch) {
+						$usedVariables[] = $object->name;
+					}
+				});
+			}
+		}
+		return $usedVariables;
 	}
 }

--- a/src/NodeVisitors/StaticAnalyzer.php
+++ b/src/NodeVisitors/StaticAnalyzer.php
@@ -32,6 +32,7 @@ use BambooHR\Guardrail\Checks\StaticPropertyFetchCheck;
 use BambooHR\Guardrail\Checks\SwitchCheck;
 use BambooHR\Guardrail\Checks\UndefinedVariableCheck;
 use BambooHR\Guardrail\Checks\UnreachableCodeCheck;
+use BambooHR\Guardrail\Checks\UnusedPrivateMemberVariableCheck;
 use BambooHR\Guardrail\Config;
 use phpDocumentor\Reflection\DocBlock\Tags\Var_;
 use phpDocumentor\Reflection\DocBlockFactory;
@@ -147,7 +148,8 @@ class StaticAnalyzer extends NodeVisitorAbstract {
 			new Psr4Check($this->index, $output),
 			new CyclomaticComplexityCheck($this->index, $output),
 			new ConditionalAssignmentCheck($this->index, $output),
-			new ClassMethodStringCheck($this->index, $output)
+			new ClassMethodStringCheck($this->index, $output),
+			new UnusedPrivateMemberVariableCheck($this->index, $output)
 		];
 
 		$this->enterHooks = $this->buildClosures();

--- a/tests/units/Checks/TestData/TestUnusedPrivateMemberVariableCheck.1.inc
+++ b/tests/units/Checks/TestData/TestUnusedPrivateMemberVariableCheck.1.inc
@@ -2,15 +2,15 @@
 
 class MyTestClass {
 
-	private $memberVariable = 'nothing';
-	private $anotherVariable = 'another thing';
+	private $memberVariable = 'my var';
+	private $anotherVariable = 'another var';
 
 	public function __construct() {
-		$this->memberVariable = 'should be ignored';
-		$this->anotherVariable = 'should be ignored';
+		$this->memberVariable = 'hello';
+		$this->anotherVariable = 'welcome';
 	}
 
 	public function testClassFunction1() {
-		$this->memberVariable = 'no';
+		$this->memberVariable = 'some value';
 	}
 }

--- a/tests/units/Checks/TestData/TestUnusedPrivateMemberVariableCheck.1.inc
+++ b/tests/units/Checks/TestData/TestUnusedPrivateMemberVariableCheck.1.inc
@@ -1,0 +1,16 @@
+<?php
+
+class MyTestClass {
+
+	private $memberVariable = 'nothing';
+	private $anotherVariable = 'another thing';
+
+	public function __construct() {
+		$this->memberVariable = 'should be ignored';
+		$this->anotherVariable = 'should be ignored';
+	}
+
+	public function testClassFunction1() {
+		$this->memberVariable = 'no';
+	}
+}

--- a/tests/units/Checks/TestData/TestUnusedPrivateMemberVariableCheck.2.inc
+++ b/tests/units/Checks/TestData/TestUnusedPrivateMemberVariableCheck.2.inc
@@ -1,0 +1,16 @@
+<?php
+
+class MyTestClass {
+
+	private $memberVariable = 'nothing';
+	private $anotherVariable = 'another thing';
+
+	public function __construct() {
+		$this->memberVariable = 'should be ignored';
+		$this->anotherVariable = 'should be ignored';
+	}
+
+	public function testClassFunction1() {
+//		$this->memberVariable = 'no';
+	}
+}

--- a/tests/units/Checks/TestData/TestUnusedPrivateMemberVariableCheck.3.inc
+++ b/tests/units/Checks/TestData/TestUnusedPrivateMemberVariableCheck.3.inc
@@ -1,0 +1,18 @@
+<?php
+
+class MyTestClass {
+
+	public $someOtherVariable;
+	protected $anotherUncheckedVariable;
+	private $memberVariable = 'nothing';
+	private $anotherVariable = 'another thing';
+
+	public function __construct() {
+		$this->memberVariable = 'should be ignored';
+		$this->anotherVariable = 'should be ignored';
+	}
+
+	public function testClassFunction1() {
+
+	}
+}

--- a/tests/units/Checks/TestData/TestUnusedPrivateMemberVariableCheck.3.inc
+++ b/tests/units/Checks/TestData/TestUnusedPrivateMemberVariableCheck.3.inc
@@ -2,14 +2,12 @@
 
 class MyTestClass {
 
-	public $someOtherVariable;
-	protected $anotherUncheckedVariable;
-	private $memberVariable = 'nothing';
-	private $anotherVariable = 'another thing';
+	private $memberVariable = 'my var';
+	private $anotherVariable = 'another var';
 
 	public function __construct() {
-		$this->memberVariable = 'should be ignored';
-		$this->anotherVariable = 'should be ignored';
+		$this->memberVariable = 'hello';
+		$this->anotherVariable = 'welcome';
 	}
 
 	public function testClassFunction1() {

--- a/tests/units/Checks/TestData/TestUnusedPrivateMemberVariableCheck.4.inc
+++ b/tests/units/Checks/TestData/TestUnusedPrivateMemberVariableCheck.4.inc
@@ -11,6 +11,7 @@ class MyTestClass {
 	}
 
 	public function testClassFunction1() {
-//		$this->memberVariable = 'some value';
+		$this->memberVariable = 'getting set';
+		$this->anotherVariable = 'used here';
 	}
 }

--- a/tests/units/Checks/TestData/TestUnusedPrivateMemberVariableCheck.5.inc
+++ b/tests/units/Checks/TestData/TestUnusedPrivateMemberVariableCheck.5.inc
@@ -11,6 +11,7 @@ class MyTestClass {
 	}
 
 	public function testClassFunction1() {
-//		$this->memberVariable = 'some value';
+		$assigned1 = $this->anotherVariable;
+		$assigned2 = $this->memberVariable;
 	}
 }

--- a/tests/units/Checks/TestUnusedPrivateMemberVariableCheck.php
+++ b/tests/units/Checks/TestUnusedPrivateMemberVariableCheck.php
@@ -16,7 +16,7 @@ class TestUnusedPrivateMemberVariableCheck extends TestSuiteSetup {
 	 * @rapid-unit Checks:UnusedPrivateMemberVariable:Catches private member variables that are not used in the class
 	 */
 	public function testUnusedPrivateMemberVariable() {
-		$this->assertEquals(1, $this->runAnalyzerOnFile('.1.inc', ErrorConstants::TYPE_UNUSED_VARIABLE));
+		$this->assertEquals(1, $this->runAnalyzerOnFile('.1.inc', ErrorConstants::TYPE_UNUSED_PROPERTY));
 	}
 
 	/**
@@ -26,7 +26,7 @@ class TestUnusedPrivateMemberVariableCheck extends TestSuiteSetup {
 	 * @rapid-unit Checks:UnusedPrivateMemberVariable:Catches private member variables that are not used in the class
 	 */
 	public function testUnusedPrivateMemberVariableIgnoresComments() {
-		$this->assertEquals(2, $this->runAnalyzerOnFile('.2.inc', ErrorConstants::TYPE_UNUSED_VARIABLE));
+		$this->assertEquals(2, $this->runAnalyzerOnFile('.2.inc', ErrorConstants::TYPE_UNUSED_PROPERTY));
 	}
 
 	/**
@@ -36,6 +36,26 @@ class TestUnusedPrivateMemberVariableCheck extends TestSuiteSetup {
 	 * @rapid-unit Checks:UnusedPrivateMemberVariable:Catches private member variables that are not used in the class
 	 */
 	public function testUnusedPrivateMemberVariableIgnoresPublicAndProtected() {
-		$this->assertEquals(2, $this->runAnalyzerOnFile('.3.inc', ErrorConstants::TYPE_UNUSED_VARIABLE));
+		$this->assertEquals(2, $this->runAnalyzerOnFile('.3.inc', ErrorConstants::TYPE_UNUSED_PROPERTY));
+	}
+
+	/**
+	 * testUnusedPrivateMemberVariableSkipsUsedVariables
+	 *
+	 * @return void
+	 * @rapid-unit Checks:UnusedPrivateMemberVariable:Catches private member variables that are not used in the class
+	 */
+	public function testUnusedPrivateMemberVariableSkipsUsedVariables() {
+		$this->assertEquals(0, $this->runAnalyzerOnFile('.4.inc', ErrorConstants::TYPE_UNUSED_PROPERTY));
+	}
+
+	/**
+	 * testUnusedPrivateMemberVariableSkipsWhenAssigned
+	 *
+	 * @return void
+	 * @rapid-unit Checks:UnusedPrivateMemberVariable:Catches private member variables that are not used in the class
+	 */
+	public function testUnusedPrivateMemberVariableSkipsWhenAssigned() {
+		$this->assertEquals(0, $this->runAnalyzerOnFile('.5.inc', ErrorConstants::TYPE_UNUSED_PROPERTY));
 	}
 }

--- a/tests/units/Checks/TestUnusedPrivateMemberVariableCheck.php
+++ b/tests/units/Checks/TestUnusedPrivateMemberVariableCheck.php
@@ -1,0 +1,41 @@
+<?php namespace BambooHR\Guardrail\Tests\Checks;
+
+use BambooHR\Guardrail\Checks\ErrorConstants;
+use BambooHR\Guardrail\Tests\TestSuiteSetup;
+
+/**
+ * Class TestUnusedPrivateMemberVariableCheck
+ * @package BambooHR\Guardrail\Tests\Checks
+ */
+class TestUnusedPrivateMemberVariableCheck extends TestSuiteSetup {
+
+	/**
+	 * testUnreachableCodeAfterIfConditional
+	 *
+	 * @return void
+	 * @rapid-unit Checks:UnusedPrivateMemberVariable:Catches private member variables that are not used in the class
+	 */
+	public function testUnusedPrivateMemberVariable() {
+		$this->assertEquals(1, $this->runAnalyzerOnFile('.1.inc', ErrorConstants::TYPE_UNUSED_VARIABLE));
+	}
+
+	/**
+	 * testUnusedPrivateMemberVariableIgnoresComments
+	 *
+	 * @return void
+	 * @rapid-unit Checks:UnusedPrivateMemberVariable:Catches private member variables that are not used in the class
+	 */
+	public function testUnusedPrivateMemberVariableIgnoresComments() {
+		$this->assertEquals(2, $this->runAnalyzerOnFile('.2.inc', ErrorConstants::TYPE_UNUSED_VARIABLE));
+	}
+
+	/**
+	 * testUnusedPrivateMemberVariableIgnoresPublicAndProtected
+	 *
+	 * @return void
+	 * @rapid-unit Checks:UnusedPrivateMemberVariable:Catches private member variables that are not used in the class
+	 */
+	public function testUnusedPrivateMemberVariableIgnoresPublicAndProtected() {
+		$this->assertEquals(2, $this->runAnalyzerOnFile('.3.inc', ErrorConstants::TYPE_UNUSED_VARIABLE));
+	}
+}


### PR DESCRIPTION
### Description
We want to check classes for unused private member variables that are not used anywhere in the object. Member variables defined in the constructor does not constitute usage. They must be used in at least one other method in the class to be considered used.

### Proposed Changes
- adding the UnusedPrivateMemberVariableCheck that will check for the Property node, loop through each statement of the $inside Class_ object and check for a PropertyFetch and add it to an array of used variables, then check the array for the name of the private member variable, when there is no match, emit error
- adding 3 new tests to make sure commented variables, public variable and protected variables are not considered used.