### PR TITLE
Small impact changes to update some error messages, and catch a protocol error

### DIFF
--- a/src/NodeVisitors/Grabber.php
+++ b/src/NodeVisitors/Grabber.php
@@ -175,7 +175,7 @@ class Grabber extends NodeVisitorAbstract {
 					$traverser->addVisitor(new TraitImportingVisitor($table));
 					$stmts = $traverser->traverse($stmts);
 				} catch (UnknownTraitException $exception) {
-					echo "Unknown trait! " . $exception->getMessage() . "\n";
+					echo "[$className] Unknown trait! " . $exception->getMessage() . "\n";
 					// Ignore these for now.
 				}
 			}

--- a/src/NodeVisitors/SymbolTableIndexer.php
+++ b/src/NodeVisitors/SymbolTableIndexer.php
@@ -15,6 +15,7 @@ use PhpParser\Node\Expr\FuncCall;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeTraverserInterface;
 use BambooHR\Guardrail\Checks\BaseCheck;
+use BambooHR\Guardrail\SymbolTable\SymbolTable;
 use PhpParser\NodeVisitorAbstract;
 
 /**
@@ -25,7 +26,7 @@ use PhpParser\NodeVisitorAbstract;
 class SymbolTableIndexer extends NodeVisitorAbstract {
 
 	/**
-	 * @var
+	 * @var SymbolTable
 	 */
 	private $index;
 
@@ -45,7 +46,7 @@ class SymbolTableIndexer extends NodeVisitorAbstract {
 	/**
 	 * SymbolTableIndexer constructor.
 	 *
-	 * @param string $index The index
+	 * @param SymbolTable $index The index
 	 */
 	public function __construct($index) {
 		$this->index = $index;

--- a/src/Phases/AnalyzingPhase.php
+++ b/src/Phases/AnalyzingPhase.php
@@ -43,6 +43,9 @@ use RecursiveIteratorIterator;
 class AnalyzingPhase {
 	private $traversers = [];
 	private $parser = null;
+	/**
+	 * @var StaticAnalyzer
+	 */
 	private $analyzer;
 	private $timingResults = [];
 
@@ -281,7 +284,7 @@ class AnalyzingPhase {
 						$output->output(".", sprintf("%d - %s", ++$processingCount, $name));
 						if ($fileNumber < count($toProcess)) {
 							$bytes += intval($size);
-							socket_write($socket, "INDEX " . $toProcess[$fileNumber] . "\n");
+							socket_write($socket, "ANALYZE " . $toProcess[$fileNumber] . "\n");
 							$fileNumber++;
 						} else {
 							socket_write($socket, "TIMINGS\n");

--- a/src/Phases/IndexingPhase.php
+++ b/src/Phases/IndexingPhase.php
@@ -110,7 +110,7 @@ class IndexingPhase {
 				$this->traverser2->traverse($statements);
 			}
 		} catch (\Exception $exc) {
-			echo "ERROR " . $exc->getMessage() . "\n";
+			echo "\n[$pathName] ERROR " . $exc->getMessage() . "\n";
 		}
 		return strlen($fileData);
 	}

--- a/src/TraitImporter.php
+++ b/src/TraitImporter.php
@@ -91,7 +91,7 @@ class TraitImporter {
 		$stmts = [];
 		foreach ($methods as $methodName => $methodArr) {
 			if (count($methodArr) > 1) {
-				echo "Too many implementations for $methodName\n";
+				echo "[{$class->name}] Too many implementations for $methodName\n";
 			}
 			foreach ($methodArr as $traitName => $method) {
 				if (!$class->getMethod($method->name)) {


### PR DESCRIPTION
- print file name before syntax error output
- print class name before duplicate method output
- print class name before unknown trait is referenced
- use ANALYZE command for the protocol with child processes when analyzing, not INDEX - child processes don't care what we send currently, but it could change.