### PR TITLE
Fix 2 bugs - fatal errors in children results in hanging parent process, calls to closures not occuring in a class caused fatal error

### DIFF
--- a/src/Checks/CallableCheck.php
+++ b/src/Checks/CallableCheck.php
@@ -57,13 +57,13 @@ class CallableCheck extends BaseCheck {
 	}
 
 	/**
-	 * @param string      $fileName      -
-	 * @param Scope       $scope         -
-	 * @param ClassLike   $inside        -
-	 * @param Expr\Array_ $callableArray -
+	 * @param string         $fileName      -
+	 * @param Scope          $scope         -
+	 * @param ClassLike|null $inside        -
+	 * @param Expr\Array_    $callableArray -
 	 * @return void
 	 */
-	protected function checkArrayCallable($fileName, Scope $scope, ClassLike $inside, Expr\Array_ $callableArray) {
+	protected function checkArrayCallable($fileName, Scope $scope, ?ClassLike $inside, Expr\Array_ $callableArray) {
 		$itemCount = count($callableArray->items);
 		if ($itemCount != 2) {
 			$this->emitError($fileName, $callableArray, ErrorConstants::TYPE_SIGNATURE_TYPE, "Callable arrays must have two parameters, $itemCount detected");

--- a/src/bin/Build.sh
+++ b/src/bin/Build.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
-php -d phar.readonly=false Build.php
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+php -d phar.readonly=false ${DIR}/Build.php


### PR DESCRIPTION
- Check for child processes that die before we read from the socket. Keep track of processes closed with non-zero status
- Close sockets for dead child processes after reading from the socket.
- Allow nullable $inside when checking callables
- improve the build script so that it can be called anywhere.
