### PR TITLE
jlesueur/guardrail fatal error bugfixes

### DIFF
--- a/src/NodeVisitors/StaticAnalyzer.php
+++ b/src/NodeVisitors/StaticAnalyzer.php
@@ -240,6 +240,7 @@ class StaticAnalyzer extends NodeVisitorAbstract {
 
 		$func[Node\Stmt\Class_::class] = function (Node\Stmt\Class_ $node) {
 			array_pop($this->classStack);
+			$this->updateClassEmit($node, "pop");
 		};
 
 		$func[ClassMethod::class] = function (ClassMethod $node) {


### PR DESCRIPTION
- Fix 2 bugs - fatal errors in children results in hanging parent process, calls to closures not occuring in a class caused fatal error
- Allow guardrail-ignore annotations to be declared on classes.
