### PR TITLE
Retry when socket write fails.

### DIFF
--- a/src/Phases/AnalyzingPhase.php
+++ b/src/Phases/AnalyzingPhase.php
@@ -323,11 +323,7 @@ class AnalyzingPhase {
 		$succeeded = false;
 		$tries = 0;
 		while ($succeeded === false && $tries < $retries) {
-			//used for testing possible socket errors, remove before merging
-			$succeed = mt_rand(0, 10);
-			if ($succeed !== 1) {
-				$succeeded = $callable();
-			}
+			$succeeded = $callable();
 			$tries++;
 		}
 		return $succeeded;

--- a/src/Phases/AnalyzingPhase.php
+++ b/src/Phases/AnalyzingPhase.php
@@ -28,6 +28,7 @@ use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\ParserFactory;
 use PhpParser\NodeTraverser;
 use BambooHR\Guardrail\Config;
+use BambooHR\Guardrail\Exceptions\SocketException;
 use BambooHR\Guardrail\NodeVisitors\TraitImportingVisitor;
 use BambooHR\Guardrail\Util;
 use BambooHR\Guardrail\NodeVisitors\StaticAnalyzer;
@@ -221,39 +222,9 @@ class AnalyzingPhase {
 		for ($fileNumber = 0; $fileNumber < $config->getProcessCount() && $fileNumber < count($toProcess); ++$fileNumber) {
 			$socket = $pm->createChild(
 				function ($socket) use ($fileNumber, $config) {
-					$table = $config->getSymbolTable();
-					if ($table instanceof PersistantSymbolTable) {
-						$table->connect(0);
-					}
-					$this->initChildThread($socket, $config);
-					$buffer = new SocketBuffer();
-					while (1) {
-						$buffer->read($socket);
-						foreach ($buffer->getMessages() as $receive) {
-							$receive = trim($receive);
-							if ($receive == "TIMINGS") {
-								socket_write($socket, "TIMINGS " . base64_encode(json_encode($this->analyzer->getTimingsAndCounts()) ). "\n");
-								return 0;
-							} else {
-								list($command, $file) = explode(' ', $receive, 2);
-								$size = $this->analyzeFile($file, $config);
-								socket_write($socket, "ANALYZED $size $file\n");
-							}
-						}
-					}
-
+					$this->runChildAnalyzer($socket, $config);
 				});
-			$succeeded = $this->retry(
-				function () use ($socket, $toProcess, $fileNumber) {
-					return false !== socket_write($socket, "ANALYZE " . $toProcess[$fileNumber] . "\n");
-				},
-				3
-			);
-			if (!$succeeded) {
-				$output->outputVerbose("Error writing to socket: " . socket_strerror(socket_last_error($socket)));
-				socket_close($socket);
-				exit(1);
-			}
+			$this->socket_write_all($socket, "ANALYZE " . $toProcess[$fileNumber] . "\n");
 		}
 
 		// Server process reports the errors and serves up new files to the list.
@@ -294,10 +265,10 @@ class AnalyzingPhase {
 						$output->output(".", sprintf("%d - %s", ++$processingCount, $name));
 						if ($fileNumber < count($toProcess)) {
 							$bytes += intval($size);
-							socket_write($socket, "ANALYZE " . $toProcess[$fileNumber] . "\n");
+							$this->socket_write_all($socket, "ANALYZE " . $toProcess[$fileNumber] . "\n");
 							$fileNumber++;
 						} else {
-							socket_write($socket, "TIMINGS\n");
+							$this->socket_write_all($socket, "TIMINGS\n");
 						}
 						if ($fileNumber % 50 == 0) {
 							$output->outputExtraVerbose(
@@ -318,14 +289,63 @@ class AnalyzingPhase {
 		return ($processDied || $output->getErrorCount() > 0 ? 1 : 0);
 	}
 
-	protected function retry($callable, $retries) {
+	/**
+	 * runChildAnalyzer
+	 *
+	 * @param  resource $socket
+	 * @param  Config $config
+	 * @return void
+	 */
+	protected function runChildAnalyzer($socket, Config $config) {
+		$table = $config->getSymbolTable();
+		if ($table instanceof PersistantSymbolTable) {
+			$table->connect(0);
+		}
+		$this->initChildThread($socket, $config);
+		$buffer = new SocketBuffer();
+		while (1) {
+			$buffer->read($socket);
+			foreach ($buffer->getMessages() as $receive) {
+				$receive = trim($receive);
+				if ($receive == "TIMINGS") {
+					$this->socket_write_all($socket, "TIMINGS " . base64_encode(json_encode($this->analyzer->getTimingsAndCounts()) ). "\n");
+					return 0;
+				} else {
+					list($command, $file) = explode(' ', $receive, 2);
+					$size = $this->analyzeFile($file, $config);
+					$this->socket_write_all($socket, "ANALYZED $size $file\n");
+				}
+			}
+		}
+	}
+
+	protected function retryOnFalse($callable, $retries) {
 		$succeeded = false;
 		$tries = 0;
-		while (!$succeeded && $tries < $retries) {
-			$succeeded = $callable();
+		while ($succeeded === false && $tries < $retries) {
+			//used for testing possible socket errors, remove before merging
+			$succeed = mt_rand(0, 10);
+			if ($succeed !== 1) {
+				$succeeded = $callable();
+			}
 			$tries++;
 		}
 		return $succeeded;
+	}
+
+	/* This function adapted from the PHP documentation on php.net */
+	protected function socket_write_all($fp, $string) {
+		$length = strlen($string);
+		$fwrite=0;
+		for ($written = 0; $written < $length; $written += $fwrite) {
+			$fwrite = $this->retryOnFalse(function () use ($fp, $string, $written) {
+				return @socket_write($fp, substr($string, $written));
+			}, 3);
+			if ($fwrite === false) {
+				throw new SocketException(socket_strerror(socket_last_error($fp)));
+			}
+		}
+		return $written;
 	}
 
 	/**

--- a/src/SocketBuffer.php
+++ b/src/SocketBuffer.php
@@ -29,18 +29,47 @@ class SocketBuffer {
 	 */
 	function read($socket) {
 		$read = "";
-		if (socket_recv($socket, $read, 4096, 0) !== false) {
-			$this->buffer .= $read;
-			do {
-				$index = self::firstEol($this->buffer);
-				if ($index !== false) {
-					$this->messages[] = trim(substr($this->buffer, 0, $index + 1), "\r\n\0\x0B");
-					$this->buffer = substr($this->buffer, $index + 1);
-				}
-			} while (strlen($this->buffer) > 0 && $index !== false);
-		} else {
+		$socketWithActionCount = $this->waitForActionOnSocket($socket);
+		if ($socketWithActionCount === 0) {
+			return;
+		}
+		$bytes = socket_recv($socket, $read, 4096, 0);
+		$isSocketDisconnected = $bytes === 0;
+		$isSocketError = $bytes === false;
+		if ($isSocketDisconnected) {
+			throw new SocketException("Socket closed unexpectedly.");
+		}
+		if ($isSocketError) {
 			throw new SocketException(socket_strerror(socket_last_error($socket)));
 		}
+		$this->buffer .= $read;
+		do {
+			$index = self::firstEol($this->buffer);
+			if ($index !== false) {
+				$this->messages[] = trim(substr($this->buffer, 0, $index + 1), "\r\n\0\x0B");
+				$this->buffer = substr($this->buffer, $index + 1);
+			}
+		} while (strlen($this->buffer) > 0 && $index !== false);
+	}
+
+	/**
+	 * waitForActionOnSocket
+	 *
+	 * When there has been action on a socket, it can either be that bytes are ready to read, or that the connection is closed.
+	 * If there is action on a socket, and the action was that the connection is closed, then socket_recv will get 0 bytes when called.
+	 *
+	 * @param  mixed $socket
+	 * @return int
+	 */
+	protected function waitForActionOnSocket($socket) {
+		$readSockets = [$socket];
+		$writeSockets = [];
+		$exceptSockets = [];
+		$results = socket_select($readSockets, $writeSockets, $exceptSockets, null, null);
+		if ($results === false) {
+			throw new SocketException(socket_strerror(socket_last_error($socket)));
+		}
+		return $results;
 	}
 
 	/**


### PR DESCRIPTION
Cihub occasionally sees guardrail hang after: 
```
Partition 1 analyzing 1286 files (4365695 bytes)
```
This seems to indicate that while children are getting spun up, none of them are doing work. We looked at possible causes, and saw that we are calling socket_write() but not checking the results. If socket_write() were failing, we would see the exact behavior of a hung ci process. 

We're not sure this is the cause, but this PR makes sure we retry the socket_write() at least three times, and bail on the entire process if we fail to write the first file for each child to the socket.