### PR TITLE
add some debugging output to try and find where we are hanging processes.

### DIFF
--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -47,6 +47,10 @@ class ProcessManager {
 		}
 	}
 
+	function getPidForSocket($socket) {
+		return array_search($socket, $this->connections);
+	}
+
 	/**
 	 * @param callable $serverReadCallBack A closure to run for the server process.
 	 * @return void


### PR DESCRIPTION
We're still seeing some hanging guardrail processes in our ci servers. We haven't been able to duplicate outside that environment. So we think we need to add some debugging to the process. We're going to limit the debugging to the first 30 files or so, to avoid spamming too much noise into the logs, since it seems like the problem occurs early in the guardrail process.

Tip: reviewing while ignoring whitespace is easier on this one.