### PR TITLE
Allow UnionType hinted parameters, updating tests.

### DIFF
--- a/src/Checks/CallCheck.php
+++ b/src/Checks/CallCheck.php
@@ -1,0 +1,110 @@
+<?php namespace BambooHR\Guardrail\Checks;
+
+use BambooHR\Guardrail\Checks\BaseCheck;
+use BambooHR\Guardrail\Checks\ErrorConstants;
+use BambooHR\Guardrail\Scope;
+use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\UnionType;
+
+abstract class CallCheck extends BaseCheck {
+	/**
+	 * @var CallableCheck
+	 */
+	protected $callableCheck;
+
+	/**
+	 * @var TypeInferrer
+	 */
+	protected $inferenceEngine;
+
+	/**
+	 * @param string                  $fileName -
+	 * @param Node                    $node     -
+	 * @param string                  $name     -
+	 * @param Scope                   $scope    -
+	 * @param ClassLike               $inside   -
+	 * @param Node\Arg                $arg      -
+	 * @param int                     $index    -
+	 * @param FunctionLikeParameter[] $params   -
+	 * @return void
+	 */
+	protected function checkParam($fileName, $node, $name, Scope $scope, ClassLike $inside = null, $arg, $index, $params) {
+		if ($scope && $arg->value instanceof Node\Expr && $index < count($params)) {
+			$variableName = $params[$index]->getName();
+			list($type, $attributes) = $this->inferenceEngine->inferType($inside, $arg->value, $scope);
+			if ($arg->unpack) {
+				// Check if they called with ...$array.  If so, make sure $array is of type undefined or array
+				$isSplatable = (
+					substr($type, -2) == "[]" ||
+					$type == "array" ||
+					$type == Scope::ARRAY_TYPE ||
+					$type == Scope::UNDEFINED ||
+					$type == Scope::MIXED_TYPE ||
+					$type == "" ||
+					$this->symbolTable->isParentClassOrInterface(\Traversable::class, $type)
+				);
+				if (!$isSplatable) {
+					$this->emitError($fileName, $node, ErrorConstants::TYPE_SIGNATURE_TYPE, "Splat (...) operator requires an array or traversable object.  Passing " . Scope::nameFromConst($type) . " from \$$variableName.");
+				}
+				return;// After we unpack an arg, we can't check the remaining parameters.
+			} else {
+				if ($params[$index]->getType() != "") {
+					// Reference mismatch
+					if ($params[$index]->isReference() &&
+						!(
+							$arg->value instanceof Variable ||
+							$arg->value instanceof Expr\ArrayDimFetch ||
+							$arg->value instanceof Expr\PropertyFetch
+						)
+					) {
+						$this->emitError($fileName, $node, ErrorConstants::TYPE_SIGNATURE_TYPE, "Value passed to $name() parameter \$$variableName must be a reference type not an expression.");
+					}
+
+					// Type mismatch
+					$expectedType = $params[$index]->getType();
+					if ($expectedType instanceof UnionType) {
+						$expectedTypes = $expectedType->types;
+					} else {
+						$expectedTypes = [$expectedType];
+					}
+					$this->verifyParamType($fileName, $node, $name, $variableName, $arg, $inside, $scope, $type, $expectedTypes);
+
+					// Nulls mismatch
+					if (!$params[$index]->isNullable()) {
+						if ($type == Scope::NULL_TYPE) {
+							$this->emitError($fileName, $node, ErrorConstants::TYPE_SIGNATURE_TYPE, "NULL passed to $name parameter \$$variableName that does not accept nulls");
+						} /*else if ($maybeNull == Scope::NULL_POSSIBLE) {
+							$this->emitError($fileName, $node, ErrorConstants::TYPE_SIGNATURE_TYPE, "Potentially NULL value passed to $name parameter \$$variableName that does not accept nulls");
+						}*/
+					}
+				}
+			}
+		}
+	}
+
+	protected function verifyParamType($fileName, $node, $name, $variableName, $arg, $inside, $scope, $type, $expectedTypes) {
+		$passedAScalar = in_array($type, [Scope::SCALAR_TYPE, Scope::MIXED_TYPE, Scope::UNDEFINED, Scope::STRING_TYPE, Scope::BOOL_TYPE, Scope::NULL_TYPE, Scope::INT_TYPE, Scope::FLOAT_TYPE]);
+		$passedTypeIsKnown = $type != '';
+		if ($passedAScalar || !$passedTypeIsKnown) {
+			return;
+		}
+		foreach ($expectedTypes as $expectedType) {
+			if ($this->symbolTable->isParentClassOrInterface($expectedType, $type)) {
+				return;
+			}
+			if ((strcasecmp($expectedType, "callable") == 0 && strcasecmp($type, "closure") == 0) ||
+				(strcasecmp($expectedType, "callable") == 0 && $type == Scope::ARRAY_TYPE) ||
+				(strcasecmp($expectedType, 'array') == 0 && (substr($type, -2) == "[]" || $type == Scope::ARRAY_TYPE))
+			) {
+				if (strcasecmp($expectedType, "callable") == 0) {
+					$this->callableCheck->run($fileName, $arg->value, $inside, $scope);
+				}
+				return;
+			}
+		}
+		$this->emitError($fileName, $node, ErrorConstants::TYPE_SIGNATURE_TYPE, "Value passed to $name parameter \$$variableName must be a $expectedType, passing $type");
+	}
+}

--- a/src/Checks/ErrorConstants.php
+++ b/src/Checks/ErrorConstants.php
@@ -9,6 +9,7 @@ class ErrorConstants {
 
 
 	const TYPE_ASSIGN_MISMATCH = 'Standard.Assign.Type';
+	const TYPE_ASSIGN_MISMATCH_SCALAR = 'Standard.Assign.ScalarType';
 	const TYPE_ACCESS_VIOLATION = 'Standard.Access.Violation';
 	const TYPE_AUTOLOAD_ERROR = 'Standard.Autoload.Unsafe';
 	const TYPE_BREAK_NUMBER = 'Standard.Switch.BreakMultiple';

--- a/src/Checks/FunctionCallCheck.php
+++ b/src/Checks/FunctionCallCheck.php
@@ -13,18 +13,9 @@ use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\ClassLike;
 use BambooHR\Guardrail\Scope;
+use PhpParser\Node\UnionType;
 
-class FunctionCallCheck extends BaseCheck {
-
-	/**
-	 * @var CallableCheck
-	 */
-	private $callableCheck;
-
-	/**
-	 * @var TypeInferrer
-	 */
-	private $inferenceEngine;
+class FunctionCallCheck extends CallCheck {
 
 	/**
 	 * FunctionCallCheck constructor.
@@ -203,79 +194,6 @@ class FunctionCallCheck extends BaseCheck {
 				$arg = $node->args[0]->value;
 				if ($arg instanceof Node\Scalar\String_ && @preg_match($arg->value, null) === false) {
 					$this->emitError($fileName, $node, ErrorConstants::TYPE_INCORRECT_REGEX, "Regular expression syntax error in \"" . $arg->value . "\"");
-				}
-			}
-		}
-	}
-
-	/**
-	 * @param string    $fileName -
-	 * @param Node      $node     -
-	 * @param string    $name     -
-	 * @param Scope     $scope    -
-	 * @param ClassLike $inside   -
-	 * @param Node\Arg  $arg      -
-	 * @param int       $index    -
-	 * @param array     $params   -
-	 * @return void
-	 */
-	protected function checkParam($fileName, $node, $name, Scope $scope, ClassLike $inside = null, $arg, $index, $params) {
-		if ($scope && $arg->value instanceof Node\Expr && $index < count($params)) {
-			$variableName = $params[$index]->getName();
-			list($type, $attributes) = $this->inferenceEngine->inferType($inside, $arg->value, $scope);
-			if ($arg->unpack) {
-				// Check if they called with ...$array.  If so, make sure $array is of type undefined or array
-				$isSplatable = (
-					substr($type, -2) == "[]" ||
-					$type == "array" ||
-					$type == Scope::ARRAY_TYPE ||
-					$type == Scope::UNDEFINED ||
-					$type == Scope::MIXED_TYPE ||
-					$this->symbolTable->isParentClassOrInterface(\Traversable::class, $type)
-				);
-				if (!$isSplatable) {
-					$this->emitError($fileName, $node, ErrorConstants::TYPE_SIGNATURE_TYPE, "Splat (...) operator requires an array or traversable object.  Passing " . Scope::nameFromConst($type) . " from \$$variableName.");
-				}
-				return;// After we unpack an arg, we can't check the remaining parameters.
-			} else {
-				if ($params[$index]->getType() != "") {
-					// Reference mismatch
-					if ($params[$index]->isReference() &&
-						!(
-							$arg->value instanceof Node\Expr\Variable ||
-							$arg->value instanceof Node\Expr\ArrayDimFetch ||
-							$arg->value instanceof Node\Expr\PropertyFetch
-						)
-					) {
-						$this->emitError($fileName, $node, ErrorConstants::TYPE_SIGNATURE_TYPE, "Value passed to $name() parameter \$$variableName must be a reference type not an expression.");
-					}
-
-					// Type mismatch
-					$expectedType = $params[$index]->getType();
-					if (!in_array($type, [Scope::SCALAR_TYPE, Scope::MIXED_TYPE, Scope::UNDEFINED, Scope::STRING_TYPE, Scope::BOOL_TYPE, Scope::NULL_TYPE, Scope::INT_TYPE, Scope::FLOAT_TYPE]) &&
-						$type != "" &&
-						!$this->symbolTable->isParentClassOrInterface($expectedType, $type) &&
-						!(strcasecmp($expectedType, "callable") == 0 && strcasecmp($type, "closure") == 0) &&
-						!(strcasecmp($expectedType, "callable") == 0 && $type == Scope::ARRAY_TYPE) &&
-						!(strcasecmp($expectedType, 'array') == 0 && (substr($type, -2) == "[]" || $type == Scope::ARRAY_TYPE))
-					) {
-						$this->emitError($fileName, $node, ErrorConstants::TYPE_SIGNATURE_TYPE, "Value passed to $name parameter \$$variableName must be a $expectedType, passing $type");
-					}
-
-					if (strcasecmp($expectedType, "callable") == 0) {
-						$this->callableCheck->run($fileName, $arg->value, $inside, $scope);
-					}
-
-					/*
-					// Nulls mismatch
-					if (!$params[$index]->isOptional()) {
-						if ($type == Scope::NULL_TYPE) {
-							$this->emitError($fileName, $node, ErrorConstants::TYPE_SIGNATURE_TYPE, "NULL passed to method " . $className . "->" . $methodName. "() parameter \$$variableName that does not accept nulls");
-						} else if ($maybeNull == Scope::NULL_POSSIBLE) {
-							$this->emitError($fileName, $node, ErrorConstants::TYPE_SIGNATURE_TYPE, "Potentially NULL value passed to method " . $className . "->" . $methodName . "() parameter \$$variableName that does not accept nulls");
-						}
-					}
-					*/
 				}
 			}
 		}

--- a/src/Checks/ParamTypesCheck.php
+++ b/src/Checks/ParamTypesCheck.php
@@ -14,6 +14,7 @@ use PhpParser\Node\Stmt\ClassLike;
 use BambooHR\Guardrail\Scope;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\UnionType;
 
 /**
  * Class ParamTypesCheck
@@ -58,7 +59,8 @@ class ParamTypesCheck extends BaseCheck {
 	 * @return string
 	 */
 	private function getNullableTypeName($type) {
-		return $type instanceof Node\NullableType ? strval($type->type) : strval($type);
+		$type = $type instanceof Node\NullableType ? $type->type : $type;
+		return $type instanceof UnionType ? 'object' : strval($type);
 	}
 
 	/**

--- a/src/Checks/PropertyStoreCheck.php
+++ b/src/Checks/PropertyStoreCheck.php
@@ -62,7 +62,6 @@ class PropertyStoreCheck extends BaseCheck {
 		if ($node instanceof Node\Expr\Assign && $node->var instanceof PropertyFetch && $node->var->name instanceof Node\Identifier) {
 			list($leftType, $leftAttributes) = $this->typeInferer->inferType($inside, $node->var, $scope);
 			list($rightType, $rightAttributes) = $this->typeInferer->inferType($inside, $node->expr, $scope);
-
 			if ($leftType && $rightType && $leftType != $rightType && $leftType != Scope::MIXED_TYPE && $rightType != Scope::MIXED_TYPE) {
 				if ($leftType[0] != "!" && $rightType[0] != "!") {
 					if (!$this->symbolTable->isParentClassOrInterface($leftType, $rightType)) {
@@ -70,6 +69,18 @@ class PropertyStoreCheck extends BaseCheck {
 					}
 				} else if (!$this->isArray($leftType) && $this->isArray($rightType)) {
 					$this->emitError($fileName, $node, ErrorConstants::TYPE_ASSIGN_MISMATCH, "Type mismatch can not assign $rightType into a $leftType");
+				} else {
+					//at least one of the parameters is scalar
+					if ($leftType[0] == '!') {
+						$leftType = Scope::nameFromConst(substr($leftType,0,2)) . substr($leftType, 2);
+					}
+					if ($rightType[0] == '!') {
+						$rightType = Scope::nameFromConst(substr($rightType, 0, 2)) . substr($rightType,2);
+					}
+
+					if (!$this->isArray($leftType) && !$this->isArray($rightType) && $rightType !== $leftType) {
+						$this->emitError($fileName, $node, ErrorConstants::TYPE_ASSIGN_MISMATCH_SCALAR, "Type mismatch can not assign $rightType into a $leftType");
+					}
 				}
 			}
 		}

--- a/src/NodeVisitors/StaticAnalyzer.php
+++ b/src/NodeVisitors/StaticAnalyzer.php
@@ -61,6 +61,7 @@ use BambooHR\Guardrail\TypeInferrer;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
 use BambooHR\Guardrail\Checks\ErrorConstants;
+use PhpParser\Node\UnionType;
 
 /**
  * Class StaticAnalyzer
@@ -753,7 +754,8 @@ class StaticAnalyzer extends NodeVisitorAbstract {
 				}
 				$scope->setVarNull(strval($param->var->name), false); // Variadic parameter will never be null.
 			} else {
-				$paramType = $param->type instanceof Node\NullableType ? strval($param->type->type) : strval($param->type);
+				$paramType = $param->type instanceof Node\NullableType ? $param->type : $param;
+				$paramType = $paramType->type instanceOf UnionType ? Scope::MIXED_TYPE : strval($paramType->type);
 				$scope->setVarType(strval($param->var->name), Scope::constFromName($paramType), $param->getLine());
 				$scope->setVarAttributes(strval($param->var->name), Attributes::TOUCHED_FUNCTION_PARAM);
 				if ($param->type != null && $param->default == null) {

--- a/src/NodeVisitors/SymbolTableIndexer.php
+++ b/src/NodeVisitors/SymbolTableIndexer.php
@@ -87,7 +87,7 @@ class SymbolTableIndexer extends NodeVisitorAbstract {
 			$this->index->addFunction($name, $node, $this->filename);
 		} elseif ($node instanceof Node\Const_) {
 			if (count($this->classStack) == 0) {
-				$defineName = strval($node->name);
+				$defineName = strval($node->namespacedName);
 				$this->index->addDefine($defineName, $node, $this->filename);
 			}
 		} elseif ($node instanceof FuncCall) {

--- a/src/Phases/AnalyzingPhase.php
+++ b/src/Phases/AnalyzingPhase.php
@@ -287,8 +287,8 @@ class AnalyzingPhase {
 					$this->socket_write_all($socket, "TIMINGS\n");
 				}
 				if ($fileNumber % 50 == 0) {
-					$output->outputExtraVerbose(
-						sprintf("Processing %.1f KB/second", $bytes / 1024 / (microtime(true) - $start))
+					$output->outputVerbose(
+						sprintf("Processing %.1f KB/second\n", $bytes / 1024 / (microtime(true) - $start))
 					);
 				}
 				break;

--- a/src/Scope.php
+++ b/src/Scope.php
@@ -47,6 +47,8 @@ class Scope {
 				return "int";
 			case static::FLOAT_TYPE:
 				return "float";
+			case static::ARRAY_TYPE:
+				return "array";
 			case static::NULL_TYPE:
 				return "null";
 			default:

--- a/src/SymbolTable/InMemorySymbolTable.php
+++ b/src/SymbolTable/InMemorySymbolTable.php
@@ -140,6 +140,9 @@ class InMemorySymbolTable extends SymbolTable {
 	 * @return mixed
 	 */
 	public function getTraitFile($name) {
+		if (!array_key_exists(strtolower($name), $this->traits)) {
+			return null;
+		}
 		return $this->traits[strtolower($name)];
 	}
 

--- a/tests/TestSuiteSetup.php
+++ b/tests/TestSuiteSetup.php
@@ -29,6 +29,12 @@ abstract class TestSuiteSetup extends TestCase {
 	 * @return int
 	 */
 	public function runAnalyzerOnFile($fileName, $emit) {
+		$output = $this->analyzeFileToOutput($fileName, $emit);
+
+		return $output->getErrorCount();
+	}
+
+	public function analyzeFileToOutput($fileName, $emit) {
 		$testDataDirectory = $this->getCallerTestDataDirectory($this);
 		if (false === strpos($fileName, $testDataDirectory)) {
 			$fileName = $testDataDirectory . $fileName;
@@ -47,8 +53,7 @@ abstract class TestSuiteSetup extends TestCase {
 		$analyzer = new AnalyzingPhase($output);
 		$analyzer->initParser($config, $output);
 		$analyzer->analyzeFile($fileName, $config);
-
-		return $output->getErrorCount();
+		return $output;
 	}
 
 	/**

--- a/tests/units/Checks/TestData/TestDefinedConstantCheck.2.inc
+++ b/tests/units/Checks/TestData/TestDefinedConstantCheck.2.inc
@@ -6,14 +6,14 @@ namespace {
 }
 
 namespace Space1 {
-	const MY_CONST_2;
+	const MY_CONST_2 = 1;
 
-	echo MY_CONST;
+	echo \MY_CONST;
 	echo \Space1\MY_CONST_2;
 	echo MY_CONST_2;
 }
 
 namespace Space2 {
 	echo \Space1\MY_CONST_2;
-	echo MY_CONST;
+	echo \MY_CONST;
 }

--- a/tests/units/Checks/TestData/TestFunctionCallCheck.9.inc
+++ b/tests/units/Checks/TestData/TestFunctionCallCheck.9.inc
@@ -1,0 +1,18 @@
+<?php
+
+class A {}
+
+class B {}
+
+function C(A | B $param) {
+
+}
+
+class D {}
+
+$a = new A();
+C($a);
+$b = new B();
+C($b);
+$d = new D();
+C($d);

--- a/tests/units/Checks/TestFunctionCallCheck.php
+++ b/tests/units/Checks/TestFunctionCallCheck.php
@@ -86,4 +86,11 @@ class TestFunctionCallCheck extends TestSuiteSetup {
 	public function testNamespaces() {
 		$this->assertEquals(0, $this->runAnalyzerOnFile('.8.inc', ErrorConstants::TYPE_UNKNOWN_FUNCTION));
 	}
+
+	/**
+	 * @return void
+	 */
+	public function testUnionTypeHints() {
+		$this->assertEquals(1, $this->runAnalyzerOnFile('.9.inc', ErrorConstants::TYPE_SIGNATURE_TYPE));
+	}
 }

--- a/tests/units/Checks/TestPropertyStoreCheck.php
+++ b/tests/units/Checks/TestPropertyStoreCheck.php
@@ -12,6 +12,7 @@ class TestPropertyStoreCheck extends TestSuiteSetup {
 	}
 
 	function testBadAssigns() {
-		$this->assertEquals(3, $this->runAnalyzerOnFile('.2.inc', ErrorConstants::TYPE_ASSIGN_MISMATCH));
+		$this->assertEquals(2, $this->runAnalyzerOnFile('.2.inc', ErrorConstants::TYPE_ASSIGN_MISMATCH));
+		$this->assertEquals(1, $this->runAnalyzerOnFile('.2.inc', ErrorConstants::TYPE_ASSIGN_MISMATCH_SCALAR));
 	}
 }


### PR DESCRIPTION
Guardrail now checks union types correctly for function and method calls
For type inference, it converts those union type hints to “mixed”. 
It includes some updates that were required to get tests to pass (which aren’t running automatically).
There is a new error type: Standard.Assign.ScalarType - this was introduced because our previous checks didn't find places where one of the expected types are scalars, and they don't match. There are too many places where this would find an error in our current code, so I made it a new type instead of using the existing Standard.Assign.Type