### PR TITLE
GRAPH-968 Handle and test union types returned from functions

### DIFF
--- a/src/Abstractions/FunctionAbstraction.php
+++ b/src/Abstractions/FunctionAbstraction.php
@@ -9,6 +9,8 @@ use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\Stmt\Function_ as AstFunction;
 use BambooHR\Guardrail\NodeVisitors\VariadicCheckVisitor;
+use BambooHR\Guardrail\Scope;
+use PhpParser\Node\UnionType;
 
 /**
  * Class FunctionAbstraction
@@ -37,6 +39,9 @@ class FunctionAbstraction implements FunctionLikeInterface {
 	 * @return string
 	 */
 	public function getReturnType() {
+		if ($this->function->returnType instanceof UnionType) {
+			return Scope::MIXED_TYPE;
+		}
 		return $this->function->returnType instanceof NullableType ? strval($this->function->returnType->type) : strval($this->function->returnType);
 	}
 

--- a/src/Checks/DocBlockTypesCheck.php
+++ b/src/Checks/DocBlockTypesCheck.php
@@ -10,6 +10,7 @@ use PhpParser\Node;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\PropertyProperty;
+use PhpParser\Node\UnionType;
 
 /**
  * Class DocBlockTypesCheck
@@ -99,7 +100,11 @@ class DocBlockTypesCheck extends BaseCheck {
 	public function run($fileName, Node $node, ClassLike $inside = null, Scope $scope = null) {
 		if ($node instanceof FunctionLike) {
 			$returnTypeOb = $node->getReturnType();
-			$return = $returnTypeOb instanceof Node\NullableType ? strval($returnTypeOb->type) : strval($returnTypeOb);
+			if ($returnTypeOb instanceOf UnionType) {
+				$return = Scope::MIXED_TYPE;
+			} else {
+				$return = $returnTypeOb instanceof Node\NullableType ? strval($returnTypeOb->type) : strval($returnTypeOb);
+			}
 			$docBlockReturn = Scope::constFromDocBlock(
 				$node->getAttribute("namespacedReturn"),
 				$inside && isset($inside->namespacedName) ? strval($inside->namespacedName) : "",

--- a/src/Checks/ReturnCheck.php
+++ b/src/Checks/ReturnCheck.php
@@ -12,6 +12,7 @@ use BambooHR\Guardrail\TypeInferrer;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Return_;
+use PhpParser\Node\UnionType;
 
 /**
  * Class ReturnCheck
@@ -80,7 +81,11 @@ class ReturnCheck extends BaseCheck {
 				return;
 			}
 			$returnType = $insideFunc->getReturnType();
-			$typeString = $returnType instanceof Node\NullableType ? strval($returnType->type) : strval($returnType);
+			if ($returnType instanceof UnionType) {
+				$typeString = Scope::MIXED_TYPE;
+			} else {
+				$typeString = $returnType instanceof Node\NullableType ? strval($returnType->type) : strval($returnType);
+			}
 			if (strcasecmp($typeString, "self") == 0 && $inside) {
 				$typeString = strval($inside->namespacedName);
 			}

--- a/src/CommandLineRunner.php
+++ b/src/CommandLineRunner.php
@@ -107,8 +107,8 @@ where: -p #/#                 = Define the number of partitions and the current 
 			$output->outputExtraVerbose("Analyzing\n");
 
 			$exitCode = $analyzer->run($config, $output);
-
-			$output->outputExtraVerbose("\nDone\n\n");
+			$output->outputVerbose("\n");
+			$output->outputExtraVerbose("Done\n\n");
 			$output->renderResults();
 
 			if ($config->shouldOutputTimings()) {

--- a/src/Config.php
+++ b/src/Config.php
@@ -341,9 +341,7 @@ class Config {
 					if ($argCount + 1 >= count($argv)) {
 						throw new InvalidConfigException;
 					}
-					$this->preferredTable = self::SQLITE_SYMBOL_TABLE;
 					$this->fileList = [$argv[++$argCount]];
-					$this->reindex = true;
 					break;
 				case '-o':
 					if ($argCount + 1 >= count($argv)) {

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -20,6 +20,7 @@ class ProcessManager {
 	const CLOSE_CONNECTION = 1;
 	const READ_CONNECTION = 2;
 	private $connections = [];
+	/** @var SocketBuffer[] */
 	private $buffers = [];
 
 	/**
@@ -105,10 +106,8 @@ class ProcessManager {
 		foreach ($messages as $msg) {
 			if (trim($msg) !== "" && self::CLOSE_CONNECTION == call_user_func($serverReadCallBack, $socket, $msg)) {
 				socket_close($socket);
-				$status = 0;
 				unset($this->connections[$index]);
 				unset($this->buffers[$index]);
-				pcntl_wait($status);
 			}
 		}
 	}

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -105,9 +105,12 @@ class ProcessManager {
 		$socket = $this->connections[$index];
 		foreach ($messages as $msg) {
 			if (trim($msg) !== "" && self::CLOSE_CONNECTION == call_user_func($serverReadCallBack, $socket, $msg)) {
+				$childPid = $this->getPidForSocket($socket);
+				$status = 0;
 				socket_close($socket);
 				unset($this->connections[$index]);
 				unset($this->buffers[$index]);
+				pcntl_waitpid($childPid, $status);
 			}
 		}
 	}

--- a/src/SocketBuffer.php
+++ b/src/SocketBuffer.php
@@ -24,7 +24,7 @@ class SocketBuffer {
 	}
 
 	/**
-	 * @param resource $socket Connection to read
+	 * @param \Socket $socket Connection to read
 	 * @return void
 	 */
 	function read($socket) {
@@ -65,7 +65,7 @@ class SocketBuffer {
 		$readSockets = [$socket];
 		$writeSockets = [];
 		$exceptSockets = [];
-		$results = socket_select($readSockets, $writeSockets, $exceptSockets, null, null);
+		$results = socket_select($readSockets, $writeSockets, $exceptSockets, null);
 		if ($results === false) {
 			throw new SocketException(socket_strerror(socket_last_error($socket)));
 		}

--- a/tests/units/Checks/TestData/TestFunctionCallCheck.9.inc
+++ b/tests/units/Checks/TestData/TestFunctionCallCheck.9.inc
@@ -4,7 +4,7 @@ class A {}
 
 class B {}
 
-function C(A | B $param) {
+function C(A | B $param): A | B {
 
 }
 


### PR DESCRIPTION
This will consider union return types as "mixed".
It also fixes our process for analyzing a single file.
It also solves a hang that happened when the last child was reaped before reading any remaining things from their socket.