### PR TITLE
Preparing Guardrail for PHP 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ nbproject
 composer.phar
 guardrail.phar
 symbol_table.sqlite3
+/symbol_table.json

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,6 @@
     "ext-pcntl": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "<6.0"
+    "phpunit/phpunit": "^9.5"
   }
 }

--- a/src/Abstractions/ClassAbstraction.php
+++ b/src/Abstractions/ClassAbstraction.php
@@ -39,7 +39,7 @@ class ClassAbstraction implements ClassInterface {
 	 *
 	 * @return string
 	 */
-	public function getName() {
+	public function getName():string {
 		$class = $this->class;
 		return isset($class->namespacedName) ? strval($class->namespacedName) : "";
 	}
@@ -49,7 +49,7 @@ class ClassAbstraction implements ClassInterface {
 	 *
 	 * @return bool
 	 */
-	public function isDeclaredAbstract() {
+	public function isDeclaredAbstract():bool {
 		$class = $this->class;
 		if ($class instanceof Class_) {
 			return $class->isAbstract();
@@ -63,7 +63,7 @@ class ClassAbstraction implements ClassInterface {
 	 *
 	 * @return array
 	 */
-	public function getMethodNames() {
+	public function getMethodNames():array {
 		$ret = [];
 		foreach ($this->class->getMethods() as $method) {
 			$ret[] = $method->name;
@@ -76,7 +76,7 @@ class ClassAbstraction implements ClassInterface {
 	 *
 	 * @return string
 	 */
-	public function getParentClassName() {
+	public function getParentClassName():string {
 		$class = $this->class;
 		if ($class instanceof \PhpParser\Node\Stmt\Class_) {
 			return strval($class->extends);
@@ -90,7 +90,7 @@ class ClassAbstraction implements ClassInterface {
 	 *
 	 * @return bool
 	 */
-	public function isInterface() {
+	public function isInterface():bool {
 		return $this->class instanceof \PhpParser\Node\Stmt\Interface_;
 	}
 
@@ -99,7 +99,7 @@ class ClassAbstraction implements ClassInterface {
 	 *
 	 * @return array
 	 */
-	public function getInterfaceNames() {
+	public function getInterfaceNames():array {
 		$ret = [];
 		$class = $this->class;
 		if ($class instanceof Interface_) {
@@ -120,9 +120,9 @@ class ClassAbstraction implements ClassInterface {
 	 *
 	 * @param string $name Instance of ClassMethod
 	 *
-	 * @return ClassMethod|null
+	 * @return MethodInterface|null
 	 */
-	public function getMethod($name) {
+	public function getMethod(string $name):?MethodInterface {
 		$method = $this->class->getMethod($name);
 		return $method ? new ClassMethod($method) : null;
 	}
@@ -134,7 +134,7 @@ class ClassAbstraction implements ClassInterface {
 	 *
 	 * @return bool
 	 */
-	public function hasConstant($name) {
+	public function hasConstant(string $name):bool {
 		$constants = Grabber::filterByType($this->class->stmts, ClassConst::class);
 		foreach ($constants as $constList) {
 			foreach ($constList->consts as $const) {
@@ -151,7 +151,7 @@ class ClassAbstraction implements ClassInterface {
 	 *
 	 * @return array
 	 */
-	public function getPropertyNames() {
+	public function getPropertyNames():array {
 		$ret = [];
 		$properties = Grabber::filterByType($this->class->stmts, \PhpParser\Node\Stmt\Property::class);
 		foreach ($properties as $prop) {
@@ -171,7 +171,7 @@ class ClassAbstraction implements ClassInterface {
 	 *
 	 * @return Property
 	 */
-	public function getProperty($name) {
+	public function getProperty(string $name):?Property {
 		$properties = Grabber::filterByType($this->class->stmts, \PhpParser\Node\Stmt\Property::class);
 		foreach ($properties as $prop) {
 			/** @var \PhpParser\Node\Stmt\Property $prop */
@@ -189,9 +189,10 @@ class ClassAbstraction implements ClassInterface {
 					if (Config::shouldUseDocBlockForProperties() && empty($type)) {
 						$type = $propertyProperty->getAttribute("namespacedType");
 					}
-					return new Property($propertyProperty->name, $type, $access, $prop->isStatic());
+					return new Property($propertyProperty->name->name, $type, $access, $prop->isStatic());
 				}
 			}
 		}
+		return null;
 	}
 }

--- a/src/Abstractions/ClassInterface.php
+++ b/src/Abstractions/ClassInterface.php
@@ -17,35 +17,35 @@ interface ClassInterface {
 	 *
 	 * @return string
 	 */
-	public function getName();
+	public function getName():string;
 
 	/**
 	 * isDeclaredAbstract
 	 *
 	 * @return bool
 	 */
-	public function isDeclaredAbstract();
+	public function isDeclaredAbstract():bool;
 
 	/**
 	 * getMethodNames
 	 *
 	 * @return array
 	 */
-	public function getMethodNames();
+	public function getMethodNames():array;
 
 	/**
 	 * getParentClassName
 	 *
 	 * @return string
 	 */
-	public function getParentClassName();
+	public function getParentClassName():string;
 
 	/**
 	 * getInterfaceNames
 	 *
 	 * @return array
 	 */
-	public function getInterfaceNames();
+	public function getInterfaceNames():array;
 
 	/**
 	 * getMethod
@@ -54,7 +54,7 @@ interface ClassInterface {
 	 *
 	 * @return ClassMethod|null
 	 */
-	public function getMethod($name);
+	public function getMethod(string $name):?MethodInterface;
 
 	/**
 	 * getProperty
@@ -63,14 +63,14 @@ interface ClassInterface {
 	 *
 	 * @return Property;
 	 */
-	public function getProperty($name);
+	public function getProperty(string $name):?Property;
 
 	/**
 	 * getPropertyNames
 	 *
 	 * @return array
 	 */
-	public function getPropertyNames();
+	public function getPropertyNames():array;
 
 	/**
 	 * hasConstant
@@ -79,12 +79,12 @@ interface ClassInterface {
 	 *
 	 * @return bool
 	 */
-	public function hasConstant($name);
+	public function hasConstant(string $name):bool;
 
 	/**
 	 * isInterface
 	 *
 	 * @return bool
 	 */
-	public function isInterface();
+	public function isInterface():bool;
 }

--- a/src/Abstractions/ClassMethod.php
+++ b/src/Abstractions/ClassMethod.php
@@ -36,14 +36,14 @@ class ClassMethod implements MethodInterface {
 	 *
 	 * @return string
 	 */
-	public function getReturnType() {
+	public function getReturnType():string {
 		return $this->method->returnType instanceof NullableType ? strval($this->method->returnType->type) : strval($this->method->returnType);
 	}
 
 	/**
 	 * @return bool
 	 */
-	public function hasNullableReturnType() {
+	public function hasNullableReturnType():bool {
 		return $this->method->returnType && $this->method->returnType instanceof NullableType;
 	}
 
@@ -52,19 +52,17 @@ class ClassMethod implements MethodInterface {
 	 *
 	 * @return bool
 	 */
-	public function isDeprecated() {
+	public function isDeprecated():bool {
 		$docBlock = $this->method->getDocComment();
-		if (strpos($docBlock, "@deprecated") !== false) {
-			return true;
-		}
+		return (strpos($docBlock, "@deprecated") !== false);
 	}
 
 	/**
 	 * getDocBlockReturnType
 	 *
-	 * @return mixed|null
+	 * @return string|null
 	 */
-	public function getDocBlockReturnType() {
+	public function getDocBlockReturnType():?string {
 		return $this->method->getAttribute('namespacedReturn');
 	}
 
@@ -73,7 +71,7 @@ class ClassMethod implements MethodInterface {
 	 *
 	 * @return int
 	 */
-	public function getMinimumRequiredParameters() {
+	public function getMinimumRequiredParameters():int {
 		$minimumArgs = 0;
 		foreach ($this->method->params as $param) {
 			if ($param->default || $param->variadic) {
@@ -89,7 +87,7 @@ class ClassMethod implements MethodInterface {
 	 *
 	 * @return FunctionLikeParameter[]
 	 */
-	public function getParameters() {
+	public function getParameters():array {
 		$ret = [];
 		/** @var \PhpParser\Node\Param $param */
 		foreach ($this->method->params as $param) {
@@ -109,7 +107,7 @@ class ClassMethod implements MethodInterface {
 	 *
 	 * @return string
 	 */
-	public function getAccessLevel() {
+	public function getAccessLevel():string {
 		return Util::getMethodAccessLevel($this->method);
 	}
 
@@ -118,7 +116,7 @@ class ClassMethod implements MethodInterface {
 	 *
 	 * @return bool
 	 */
-	public function isInternal() {
+	public function isInternal():bool {
 		return false;
 	}
 
@@ -127,7 +125,7 @@ class ClassMethod implements MethodInterface {
 	 *
 	 * @return bool
 	 */
-	public function isAbstract() {
+	public function isAbstract():bool {
 		return $this->method->isAbstract();
 	}
 
@@ -136,7 +134,7 @@ class ClassMethod implements MethodInterface {
 	 *
 	 * @return bool
 	 */
-	public function isStatic() {
+	public function isStatic():bool {
 		return $this->method->isStatic();
 	}
 
@@ -145,8 +143,8 @@ class ClassMethod implements MethodInterface {
 	 *
 	 * @return string
 	 */
-	public function getName() {
-		return $this->method->name;
+	public function getName():string {
+		return $this->method->name->name;
 	}
 
 	/**
@@ -154,7 +152,7 @@ class ClassMethod implements MethodInterface {
 	 *
 	 * @return int
 	 */
-	public function getStartingLine() {
+	public function getStartingLine():int {
 		return $this->method->getLine();
 	}
 
@@ -163,7 +161,7 @@ class ClassMethod implements MethodInterface {
 	 *
 	 * @return bool
 	 */
-	public function isVariadic() {
+	public function isVariadic():bool {
 		foreach ($this->method->getParams() as $param) {
 			if ($param->variadic) {
 				return true;

--- a/src/Abstractions/FunctionAbstraction.php
+++ b/src/Abstractions/FunctionAbstraction.php
@@ -38,7 +38,7 @@ class FunctionAbstraction implements FunctionLikeInterface {
 	 *
 	 * @return string
 	 */
-	public function getReturnType() {
+	public function getReturnType():string {
 		if ($this->function->returnType instanceof UnionType) {
 			return Scope::MIXED_TYPE;
 		}
@@ -48,7 +48,7 @@ class FunctionAbstraction implements FunctionLikeInterface {
 	/**
 	 * @return bool
 	 */
-	public function hasNullableReturnType() {
+	public function hasNullableReturnType():bool {
 		return $this->function->returnType instanceof NullableType;
 	}
 
@@ -58,7 +58,7 @@ class FunctionAbstraction implements FunctionLikeInterface {
 	 *
 	 * @return bool
 	 */
-	public function isDeprecated() {
+	public function isDeprecated():bool {
 		$docBlock = $this->function->getDocComment();
 		if (strpos($docBlock, "@deprecated") !== false) {
 			return true;
@@ -71,7 +71,7 @@ class FunctionAbstraction implements FunctionLikeInterface {
 	 *
 	 * @return mixed|null
 	 */
-	public function getDocBlockReturnType() {
+	public function getDocBlockReturnType():?string {
 		return $this->function->getAttribute('namespacedReturn');
 	}
 
@@ -80,7 +80,7 @@ class FunctionAbstraction implements FunctionLikeInterface {
 	 *
 	 * @return int
 	 */
-	public function getMinimumRequiredParameters() {
+	public function getMinimumRequiredParameters():int {
 		$minimumArgs = 0;
 		foreach ($this->function->params as $param) {
 			if ($param->default) {
@@ -96,7 +96,7 @@ class FunctionAbstraction implements FunctionLikeInterface {
 	 *
 	 * @return FunctionLikeParameter[]
 	 */
-	public function getParameters() {
+	public function getParameters():array {
 		$ret = [];
 		/** @var \PhpParser\Node\Param $param */
 		foreach ($this->function->params as $param) {
@@ -116,7 +116,7 @@ class FunctionAbstraction implements FunctionLikeInterface {
 	 *
 	 * @return bool
 	 */
-	public function isInternal() {
+	public function isInternal():bool {
 		return false;
 	}
 
@@ -125,8 +125,8 @@ class FunctionAbstraction implements FunctionLikeInterface {
 	 *
 	 * @return string
 	 */
-	public function getName() {
-		return $this->function->name;
+	public function getName():string {
+		return $this->function->name->name;
 	}
 
 	/**
@@ -134,7 +134,7 @@ class FunctionAbstraction implements FunctionLikeInterface {
 	 *
 	 * @return int
 	 */
-	public function getStartingLine() {
+	public function getStartingLine():int {
 		return $this->function->getLine();
 	}
 
@@ -143,7 +143,7 @@ class FunctionAbstraction implements FunctionLikeInterface {
 	 *
 	 * @return bool
 	 */
-	public function isVariadic() {
+	public function isVariadic():bool {
 		foreach ($this->function->getParams() as $param) {
 			if ($param->variadic) {
 				return true;

--- a/src/Abstractions/FunctionLikeInterface.php
+++ b/src/Abstractions/FunctionLikeInterface.php
@@ -17,68 +17,68 @@ interface FunctionLikeInterface {
 	 *
 	 * @return FunctionLikeParameter[]
 	 */
-	public function getParameters();
+	public function getParameters():array;
 
 	/**
 	 * getMinimumRequiredParameters
 	 *
-	 * @return mixed
+	 * @return int
 	 */
-	public function getMinimumRequiredParameters();
+	public function getMinimumRequiredParameters():int;
 
 	/**
 	 * getReturnType
 	 *
 	 * @return string
 	 */
-	public function getReturnType();
+	public function getReturnType():string;
 
 	/**
 	 * hasNulllableReturnType
 	 *
 	 * @return bool
 	 */
-	public function hasNullableReturnType();
+	public function hasNullableReturnType():bool;
 
 	/**
 	 * getDocBlockReturnType
 	 *
 	 * @return string|null
 	 */
-	public function getDocBlockReturnType();
+	public function getDocBlockReturnType():?string;
 
 	/**
 	 * isInternal
 	 *
 	 * @return bool
 	 */
-	public function isInternal();
+	public function isInternal():bool;
 
 	/**
 	 * isDeprecated
 	 *
 	 * @return bool
 	 */
-	public function isDeprecated();
+	public function isDeprecated():bool;
 
 	/**
 	 * getName
 	 *
 	 * @return string
 	 */
-	public function getName();
+	public function getName():string;
 
 	/**
 	 * getStartingLine
 	 *
 	 * @return int
 	 */
-	public function getStartingLine();
+	public function getStartingLine():int;
 
 	/**
 	 * isVariadic
 	 *
 	 * @return bool
 	 */
-	public function isVariadic();
+	public function isVariadic():bool;
 }

--- a/src/Abstractions/FunctionLikeParameter.php
+++ b/src/Abstractions/FunctionLikeParameter.php
@@ -1,5 +1,7 @@
 <?php namespace BambooHR\Guardrail\Abstractions;
 
+use PhpParser\Node\UnionType;
+
 /**
  * Guardrail.  Copyright (c) 2016-2017, Jonathan Gardiner and BambooHR.
  * Apache 2.0 License
@@ -13,41 +15,41 @@
 class FunctionLikeParameter {
 
 	/**
-	 * @var string
+	 * @var string|UnionType
 	 */
 	private $type;
 
 	/**
 	 * @var string
 	 */
-	private $name;
+	private string $name;
 
 	/**
 	 * @var bool
 	 */
-	private $optional;
+	private bool $optional;
 
 	/**
 	 * @var bool
 	 */
-	private $reference;
+	private bool $reference;
 
 	/**
 	 * @var bool
 	 */
-	private $nullable;
+	private bool $nullable;
 
 	/**
 	 * FunctionLikeParameter constructor.
 	 *
-	 * @param string $type      The type
-	 * @param string $name      The name
-	 * @param bool   $optional  Is it optional
-	 * @param bool   $reference Is it a reference
-	 * @param bool   $nullable  Is it nullable
+	 * @param string|UnionType $type The type
+	 * @param string           $name The name
+	 * @param bool             $optional Is it optional
+	 * @param bool             $reference Is it a reference
+	 * @param bool             $nullable Is it nullable
 	 */
-	public function __construct($type, $name, $optional, $reference, $nullable) {
-		$this->type = $type;
+	public function __construct($type, string $name, bool $optional, bool $reference, bool $nullable) {
+		$this->type = ($type === NULL ? "" : $type);
 		$this->name = $name;
 		$this->optional = $optional;
 		$this->reference = $reference;
@@ -57,7 +59,7 @@ class FunctionLikeParameter {
 	/**
 	 * getType
 	 *
-	 * @return string
+	 * @return string|UnionType
 	 */
 	public function getType() {
 		return $this->type;
@@ -68,7 +70,7 @@ class FunctionLikeParameter {
 	 *
 	 * @return string
 	 */
-	public function getName() {
+	public function getName():string {
 		return $this->name;
 	}
 
@@ -77,7 +79,7 @@ class FunctionLikeParameter {
 	 *
 	 * @return bool
 	 */
-	public function isOptional() {
+	public function isOptional():bool {
 		return $this->optional;
 	}
 
@@ -86,14 +88,14 @@ class FunctionLikeParameter {
 	 *
 	 * @return bool
 	 */
-	public function isReference() {
+	public function isReference():bool {
 		return $this->reference;
 	}
 
 	/**
 	 * @return bool
 	 */
-	public function isNullable() {
+	public function isNullable():bool {
 		return $this->nullable;
 	}
 }

--- a/src/Abstractions/FunctionLikeParameter.php
+++ b/src/Abstractions/FunctionLikeParameter.php
@@ -22,22 +22,22 @@ class FunctionLikeParameter {
 	/**
 	 * @var string
 	 */
-	private string $name;
+	private $name;
 
 	/**
 	 * @var bool
 	 */
-	private bool $optional;
+	private $optional;
 
 	/**
 	 * @var bool
 	 */
-	private bool $reference;
+	private $reference;
 
 	/**
 	 * @var bool
 	 */
-	private bool $nullable;
+	private $nullable;
 
 	/**
 	 * FunctionLikeParameter constructor.

--- a/src/Abstractions/MethodInterface.php
+++ b/src/Abstractions/MethodInterface.php
@@ -17,29 +17,29 @@ interface MethodInterface extends FunctionLikeInterface {
 	 *
 	 * @return bool
 	 */
-	public function isAbstract();
+	public function isAbstract():bool;
 
 	/**
 	 * isStatic
 	 *
 	 * @return bool
 	 */
-	public function isStatic();
+	public function isStatic():bool;
 
 	/**
 	 * getAccessLevel
 	 *
 	 * @return string
 	 */
-	public function getAccessLevel();
+	public function getAccessLevel():string;
 
 	/**
 	 * @return bool
 	 */
-	public function hasNullableReturnType();
+	public function hasNullableReturnType():bool;
 
 	/**
 	 * @return string
 	 */
-	public function getReturnType();
+	public function getReturnType():string;
 }

--- a/src/Abstractions/Property.php
+++ b/src/Abstractions/Property.php
@@ -40,10 +40,10 @@ class Property {
 	 * @param string $access   The access
 	 * @param bool   $isStatic Is it static
 	 */
-	public function __construct($name,$type, $access, $isStatic) {
+	public function __construct(string $name,?string $type, string $access,bool $isStatic) {
 		$this->name = $name;
 		$this->access = $access;
-		$this->type = $type;
+		$this->type = ($type === null ? "" : $type);
 		$this->static = $isStatic;
 	}
 
@@ -52,7 +52,7 @@ class Property {
 	 *
 	 * @return string
 	 */
-	public function getName() {
+	public function getName():string {
 		return $this->name;
 	}
 
@@ -61,7 +61,7 @@ class Property {
 	 *
 	 * @return string
 	 */
-	public function getAccess() {
+	public function getAccess():string {
 		return $this->access;
 	}
 
@@ -70,7 +70,7 @@ class Property {
 	 *
 	 * @return string
 	 */
-	public function getType() {
+	public function getType():string {
 		return $this->type;
 	}
 
@@ -79,7 +79,7 @@ class Property {
 	 *
 	 * @return bool
 	 */
-	public function isStatic() {
+	public function isStatic():bool {
 		return $this->static;
 	}
 }

--- a/src/Abstractions/ReflectedClass.php
+++ b/src/Abstractions/ReflectedClass.php
@@ -31,7 +31,7 @@ class ReflectedClass implements ClassInterface {
 	 *
 	 * @return string
 	 */
-	public function getParentClassName() {
+	public function getParentClassName():string {
 		$parent = $this->refl->getParentClass();
 		return $parent ? $parent->getName() : "";
 	}
@@ -41,7 +41,7 @@ class ReflectedClass implements ClassInterface {
 	 *
 	 * @return array
 	 */
-	public function getInterfaceNames() {
+	public function getInterfaceNames():array {
 		$names = $this->refl->getInterfaceNames();
 		if (strcasecmp($this->refl->name, 'exception') == 0) {
 			$names[] = 'Throwable';
@@ -54,7 +54,7 @@ class ReflectedClass implements ClassInterface {
 	 *
 	 * @return bool
 	 */
-	public function isInterface() {
+	public function isInterface():bool {
 		return $this->refl->isInterface();
 	}
 
@@ -63,7 +63,7 @@ class ReflectedClass implements ClassInterface {
 	 *
 	 * @return bool
 	 */
-	public function isDeclaredAbstract() {
+	public function isDeclaredAbstract():bool {
 		return $this->refl->isAbstract();
 	}
 
@@ -72,7 +72,7 @@ class ReflectedClass implements ClassInterface {
 	 *
 	 * @return array
 	 */
-	public function getMethodNames() {
+	public function getMethodNames():array {
 		$ret = [];
 		foreach ($this->refl->getMethods() as $method) {
 			$ret[] = $method->name;
@@ -87,7 +87,7 @@ class ReflectedClass implements ClassInterface {
 	 *
 	 * @return bool
 	 */
-	public function hasConstant($name) {
+	public function hasConstant(string $name):bool {
 		$constants = $this->refl->getConstants();
 		return array_key_exists($name, $constants);
 	}
@@ -97,9 +97,9 @@ class ReflectedClass implements ClassInterface {
 	 *
 	 * @param string $name The name of the method to get
 	 *
-	 * @return \BambooHR\Guardrail\Abstractions\ReflectedClassMethod|null
+	 * @return MethodInterface|null
 	 */
-	public function getMethod($name) {
+	public function getMethod(string $name):?MethodInterface {
 		try {
 			$method = $this->refl->getMethod($name);
 			if ($method) {
@@ -116,7 +116,7 @@ class ReflectedClass implements ClassInterface {
 	 *
 	 * @return string
 	 */
-	public function getName() {
+	public function getName():string {
 		return $this->refl->getName();
 	}
 
@@ -127,7 +127,7 @@ class ReflectedClass implements ClassInterface {
 	 *
 	 * @return Property|null
 	 */
-	public function getProperty($name) {
+	public function getProperty(string $name):?Property {
 		try {
 			$prop = $this->refl->getProperty($name);
 			if ($prop) {
@@ -153,7 +153,7 @@ class ReflectedClass implements ClassInterface {
 	 *
 	 * @return array
 	 */
-	public function getPropertyNames() {
+	public function getPropertyNames():array {
 		$ret = [];
 		$props = $this->refl->getProperties();
 		foreach ($props as $prop) {

--- a/src/Abstractions/ReflectedClassMethod.php
+++ b/src/Abstractions/ReflectedClassMethod.php
@@ -31,7 +31,7 @@ class ReflectedClassMethod implements MethodInterface {
 	 *
 	 * @return bool
 	 */
-	public function isStatic() {
+	public function isStatic():bool {
 		return $this->refl->isStatic();
 	}
 
@@ -40,7 +40,7 @@ class ReflectedClassMethod implements MethodInterface {
 	 *
 	 * @return bool
 	 */
-	public function isDeprecated() {
+	public function isDeprecated():bool {
 		return $this->refl->isDeprecated();
 	}
 
@@ -49,7 +49,7 @@ class ReflectedClassMethod implements MethodInterface {
 	 *
 	 * @return bool
 	 */
-	public function isInternal() {
+	public function isInternal():bool {
 		return true;
 	}
 
@@ -58,7 +58,7 @@ class ReflectedClassMethod implements MethodInterface {
 	 * @guardrail-ignore Standard.Unknown.Class.Method
 	 * @return string
 	 */
-	public function getReturnType() {
+	public function getReturnType():string {
 		if ( method_exists($this->refl, "getReturnType")) {
 			$type = $this->refl->getReturnType();
 			if ($type) {
@@ -73,7 +73,7 @@ class ReflectedClassMethod implements MethodInterface {
 	 *
 	 * @return string
 	 */
-	public function getDocBlockReturnType() {
+	public function getDocBlockReturnType():string {
 		return "";
 	}
 
@@ -82,7 +82,7 @@ class ReflectedClassMethod implements MethodInterface {
 	 *
 	 * @return bool
 	 */
-	public function isAbstract() {
+	public function isAbstract():bool {
 		return $this->refl->isAbstract();
 	}
 
@@ -91,7 +91,7 @@ class ReflectedClassMethod implements MethodInterface {
 	 *
 	 * @return string
 	 */
-	public function getAccessLevel() {
+	public function getAccessLevel():string {
 		if ($this->refl->isPrivate()) {
 			return "private";
 		}
@@ -108,7 +108,7 @@ class ReflectedClassMethod implements MethodInterface {
 	 *
 	 * @return int
 	 */
-	public function getMinimumRequiredParameters() {
+	public function getMinimumRequiredParameters():int {
 
 		$class = strtolower($this->refl->getDeclaringClass()->getName());
 		$method = strtolower($this->refl->getName());
@@ -128,7 +128,7 @@ class ReflectedClassMethod implements MethodInterface {
 	 *
 	 * @return array
 	 */
-	public function getParameters() {
+	public function getParameters():array {
 		$ret = [];
 		$params = $this->refl->getParameters();
 		/** @var \ReflectionParameter $param */
@@ -143,7 +143,7 @@ class ReflectedClassMethod implements MethodInterface {
 	 * @guardrail-ignore Standard.Unknown.Class.Method
 	 * @return bool
 	 */
-	public function hasNullableReturnType() {
+	public function hasNullableReturnType():bool {
 		if ( method_exists($this->refl, "getReturnType")) {
 			$type = $this->refl->getReturnType();
 			if ($type) {
@@ -158,7 +158,7 @@ class ReflectedClassMethod implements MethodInterface {
 	 *
 	 * @return string
 	 */
-	public function getName() {
+	public function getName():string {
 		return $this->refl->getName();
 	}
 
@@ -167,7 +167,7 @@ class ReflectedClassMethod implements MethodInterface {
 	 *
 	 * @return int
 	 */
-	public function getStartingLine() {
+	public function getStartingLine():int {
 		return 0;
 	}
 
@@ -177,7 +177,7 @@ class ReflectedClassMethod implements MethodInterface {
 	 * @return bool
 	 * @guardrail-ignore Standard.Unknown.Class.Method
 	 */
-	public function isVariadic() {
+	public function isVariadic():bool {
 		if (method_exists($this->refl, "isVariadic")) {
 			return $this->refl->isVariadic();
 		} else {

--- a/src/Abstractions/ReflectedFunction.php
+++ b/src/Abstractions/ReflectedFunction.php
@@ -1,5 +1,7 @@
 <?php namespace BambooHR\Guardrail\Abstractions;
 
+use BambooHR\Guardrail\Scope;
+
 /**
  * Guardrail.  Copyright (c) 2016-2017, Jonathan Gardiner and BambooHR.
  * Apache 2.0 License
@@ -30,9 +32,9 @@ class ReflectedFunction implements FunctionLikeInterface {
 	/**
 	 * isStatic
 	 *
-	 * @return mixed
+	 * @return bool
 	 */
-	public function isStatic() {
+	public function isStatic():bool {
 		return false;
 	}
 
@@ -41,7 +43,7 @@ class ReflectedFunction implements FunctionLikeInterface {
 	 *
 	 * @return bool
 	 */
-	public function isDeprecated() {
+	public function isDeprecated():bool {
 		return $this->refl->isDeprecated();
 	}
 
@@ -50,7 +52,7 @@ class ReflectedFunction implements FunctionLikeInterface {
 	 *
 	 * @return bool
 	 */
-	public function isInternal() {
+	public function isInternal():bool {
 		return true;
 	}
 
@@ -59,11 +61,13 @@ class ReflectedFunction implements FunctionLikeInterface {
 	 * @guardrail-ignore Standard.Unknown.Class.Method
 	 * @return string
 	 */
-	public function getReturnType() {
+	public function getReturnType():string {
 		if ( method_exists($this->refl, "getReturnType")) {
 			$type = $this->refl->getReturnType();
-			if ($type) {
+			if ($type instanceof \ReflectionNamedType) {
 				return $type->getName();
+			} else if ($type instanceof \ReflectionUnionType) {
+				return Scope::MIXED_TYPE;
 			}
 		}
 		return "";
@@ -73,7 +77,7 @@ class ReflectedFunction implements FunctionLikeInterface {
 	 * @guardrail-ignore Standard.Unknown.Class.Method
 	 * @return bool
 	 */
-	public function hasNullableReturnType() {
+	public function hasNullableReturnType():bool {
 		if ( method_exists($this->refl, "getReturnType")) {
 			$type = $this->refl->getReturnType();
 			if ($type) {
@@ -88,7 +92,7 @@ class ReflectedFunction implements FunctionLikeInterface {
 	 *
 	 * @return mixed
 	 */
-	public function isAbstract() {
+	public function isAbstract():bool {
 		return false;
 	}
 
@@ -97,7 +101,7 @@ class ReflectedFunction implements FunctionLikeInterface {
 	 *
 	 * @return string
 	 */
-	public function getDocBlockReturnType() {
+	public function getDocBlockReturnType():string {
 		return "";
 	}
 
@@ -106,7 +110,7 @@ class ReflectedFunction implements FunctionLikeInterface {
 	 *
 	 * @return string
 	 */
-	public function getAccessLevel() {
+	public function getAccessLevel():string {
 		return "public";
 	}
 
@@ -115,7 +119,7 @@ class ReflectedFunction implements FunctionLikeInterface {
 	 *
 	 * @return int|mixed
 	 */
-	public function getMinimumRequiredParameters() {
+	public function getMinimumRequiredParameters():int {
 		$min = self::getOverriddenMinimumParams($this->refl->name);
 		return $min >= 0 ? $min : $this->refl->getNumberOfRequiredParameters();
 	}
@@ -125,9 +129,9 @@ class ReflectedFunction implements FunctionLikeInterface {
 	 *
 	 * @param string $name The name
 	 *
-	 * @return int|mixed
+	 * @return int
 	 */
-	private static function getOverriddenMinimumParams($name) {
+	private static function getOverriddenMinimumParams($name):int {
 		static $overrides = [
 			"define" => 2,
 			"implode" => 1,
@@ -146,7 +150,7 @@ class ReflectedFunction implements FunctionLikeInterface {
 	 *
 	 * @return array
 	 */
-	public function getParameters() {
+	public function getParameters():array{
 		$ret = [];
 		$params = $this->refl->getParameters();
 		/** @var \ReflectionParameter $param */
@@ -190,7 +194,7 @@ class ReflectedFunction implements FunctionLikeInterface {
 	 *
 	 * @return string
 	 */
-	public function getName() {
+	public function getName():string {
 		return $this->refl->getName();
 	}
 
@@ -199,7 +203,7 @@ class ReflectedFunction implements FunctionLikeInterface {
 	 *
 	 * @return int
 	 */
-	public function getStartingLine() {
+	public function getStartingLine():int {
 		return 0;
 	}
 
@@ -209,7 +213,7 @@ class ReflectedFunction implements FunctionLikeInterface {
 	 * @return bool
 	 * @guardrail-ignore Standard.Unknown.Class.Method
 	 */
-	public function isVariadic() {
+	public function isVariadic():bool {
 		if (method_exists($this->refl, "isVariadic")) {
 			return $this->refl->isVariadic();
 		} else {

--- a/src/Checks/AccessingSuperGlobalsCheck.php
+++ b/src/Checks/AccessingSuperGlobalsCheck.php
@@ -17,7 +17,7 @@ class AccessingSuperGlobalsCheck extends BaseCheck {
 	 *
 	 * @return array
 	 */
-	public function getCheckNodeTypes() {
+	public function getCheckNodeTypes(): array {
 		return [Global_::class, Variable::class];
 	}
 
@@ -25,13 +25,13 @@ class AccessingSuperGlobalsCheck extends BaseCheck {
 	 * run
 	 *
 	 * @param string                   $fileName The name of the file being parsed
-	 * @param Node                     $node     Reference to the object in the AST
-	 * @param Node\Stmt\ClassLike|null $inside   Instance of the ClassLike (the class we are in)
-	 * @param Scope|null               $scope    Instance of the Scope (all variables in current state)
+	 * @param Node                     $node Reference to the object in the AST
+	 * @param Node\Stmt\ClassLike|null $inside Instance of the ClassLike (the class we are in)
+	 * @param Scope|null               $scope Instance of the Scope (all variables in current state)
 	 *
 	 * @return void
 	 */
-	public function run($fileName, Node $node, Node\Stmt\ClassLike $inside = null, Scope $scope = null) {
+	public function run(string $fileName, Node $node, Node\Stmt\ClassLike $inside = null, Scope $scope = null) {
 		if ($node instanceof Global_) {
 			$this->checkForGlobal($fileName, $node);
 		}

--- a/src/Checks/BackTickOperatorCheck.php
+++ b/src/Checks/BackTickOperatorCheck.php
@@ -22,7 +22,7 @@ class BackTickOperatorCheck extends BaseCheck {
 	 *
 	 * @return string[]
 	 */
-	public function getCheckNodeTypes() {
+	public function getCheckNodeTypes(): array {
 		return [ShellExec::class];
 	}
 
@@ -30,13 +30,13 @@ class BackTickOperatorCheck extends BaseCheck {
 	 * run
 	 *
 	 * @param string         $fileName The name of the file we are parsing
-	 * @param Node           $node     Instance of the Node
-	 * @param ClassLike|null $inside   Instance of the ClassLike (the class we are parsing) [optional]
-	 * @param Scope|null     $scope    Instance of the Scope (all variables in the current state) [optional]
+	 * @param Node           $node Instance of the Node
+	 * @param ClassLike|null $inside Instance of the ClassLike (the class we are parsing) [optional]
+	 * @param Scope|null     $scope Instance of the Scope (all variables in the current state) [optional]
 	 *
 	 * @return void
 	 */
-	public function run($fileName, Node $node, ClassLike $inside=null, Scope $scope=null) {
+	public function run(string $fileName, Node $node, ClassLike $inside=null, Scope $scope=null) {
 		if ($node instanceof ShellExec) {
 			$this->emitError($fileName, $node, ErrorConstants::TYPE_SECURITY_BACKTICK, "Unsafe operator (back tick)");
 		}

--- a/src/Checks/BaseCheck.php
+++ b/src/Checks/BaseCheck.php
@@ -38,14 +38,14 @@ abstract class BaseCheck extends ErrorConstants {
 	/**
 	 * emitError
 	 *
-	 * @param string $file    The file
-	 * @param Node   $node    Instance of the Node
-	 * @param string $class   The name of the class
+	 * @param string $file The file
+	 * @param Node   $node Instance of the Node
+	 * @param string $class The name of the class
 	 * @param string $message The message
 	 *
 	 * @return mixed
 	 */
-	public function emitError($file, \PhpParser\Node $node, $class, $message="") {
+	public function emitError(string $file, \PhpParser\Node $node, string $class, string $message="") {
 		$trait = $node->getAttribute("importedFromTrait");
 		if ($trait) {
 			$trait = str_replace("//", "/", $trait);
@@ -59,14 +59,14 @@ abstract class BaseCheck extends ErrorConstants {
 	/**
 	 * emitErrorOnLine
 	 *
-	 * @param string $file       The file name
+	 * @param string $file The file name
 	 * @param int    $lineNumber The line number
-	 * @param string $class      The class
-	 * @param string $message    The message
+	 * @param string $class The class
+	 * @param string $message The message
 	 *
 	 * @return mixed
 	 */
-	public function emitErrorOnLine($file, $lineNumber, $class, $message="") {
+	public function emitErrorOnLine(string $file, int $lineNumber, string $class, string $message="") {
 		return $this->doc->emitError(get_class($this), $file, $lineNumber, $class, $message);
 	}
 
@@ -84,17 +84,17 @@ abstract class BaseCheck extends ErrorConstants {
 	 *
 	 * @return string[]
 	 */
-	abstract function getCheckNodeTypes();
+	abstract function getCheckNodeTypes(): array;
 
 	/**
 	 * run
 	 *
 	 * @param string         $fileName The name of the file we are parsing
-	 * @param Node           $node     Instance of the Node
-	 * @param ClassLike|null $inside   Instance of the ClassLike (the class we are parsing) [optional]
-	 * @param Scope|null     $scope    Instance of the Scope (all variables in the current state) [optional]
+	 * @param Node           $node Instance of the Node
+	 * @param ClassLike|null $inside Instance of the ClassLike (the class we are parsing) [optional]
+	 * @param Scope|null     $scope Instance of the Scope (all variables in the current state) [optional]
 	 *
 	 * @return void
 	 */
-	abstract public function run($fileName, Node $node, ClassLike $inside = null, Scope $scope = null);
+	abstract public function run(string $fileName, Node $node, ClassLike $inside = null, Scope $scope = null);
 }

--- a/src/Checks/BreakCheck.php
+++ b/src/Checks/BreakCheck.php
@@ -23,7 +23,7 @@ class BreakCheck extends BaseCheck {
 	 *
 	 * @return string[]
 	 */
-	public function getCheckNodeTypes() {
+	public function getCheckNodeTypes(): array {
 		return [ Break_::class, Continue_::class ];
 	}
 
@@ -31,13 +31,13 @@ class BreakCheck extends BaseCheck {
 	 * run
 	 *
 	 * @param string         $fileName The name of the file we are parsing
-	 * @param Node           $node     Instance of the Node
-	 * @param ClassLike|null $inside   Instance of the ClassLike (the class we are parsing) [optional]
-	 * @param Scope|null     $scope    Instance of the Scope (all variables in the current state) [optional]
+	 * @param Node           $node Instance of the Node
+	 * @param ClassLike|null $inside Instance of the ClassLike (the class we are parsing) [optional]
+	 * @param Scope|null     $scope Instance of the Scope (all variables in the current state) [optional]
 	 *
 	 * @return void
 	 */
-	public function run($fileName, Node $node, ClassLike $inside = null, Scope $scope = null) {
+	public function run(string $fileName, Node $node, ClassLike $inside = null, Scope $scope = null) {
 		if ($node instanceof Break_) {
 			if ($node->num != null) {
 				$this->emitError($fileName, $node, ErrorConstants::TYPE_BREAK_NUMBER, "Usage of unsafe \"break [expression]\" form");

--- a/src/Checks/CallableCheck.php
+++ b/src/Checks/CallableCheck.php
@@ -51,7 +51,7 @@ class CallableCheck extends BaseCheck {
 	 *
 	 * @return array|string[]
 	 */
-	function getCheckNodeTypes() {
+	function getCheckNodeTypes(): array {
 		return [];
 
 	}
@@ -102,12 +102,12 @@ class CallableCheck extends BaseCheck {
 	/**
 	 *
 	 * @param string         $fileName -
-	 * @param Node           $node     -
-	 * @param ClassLike|null $inside   -
-	 * @param Scope|null     $scope    -l
+	 * @param Node           $node -
+	 * @param ClassLike|null $inside -
+	 * @param Scope|null     $scope -l
 	 * @return void
 	 */
-	public function run($fileName, Node $node, ClassLike $inside = null, Scope $scope = null) {
+	public function run(string $fileName, Node $node, ClassLike $inside = null, Scope $scope = null) {
 		if ($node instanceof Node\Scalar\String_) {
 			$funcName = $node->value;
 			if ($funcName && $funcName[0] == "\\") {

--- a/src/Checks/CatchCheck.php
+++ b/src/Checks/CatchCheck.php
@@ -24,7 +24,7 @@ class CatchCheck extends BaseCheck {
 	 *
 	 * @return string[]
 	 */
-	public function getCheckNodeTypes() {
+	public function getCheckNodeTypes(): array {
 		return [Catch_::class];
 	}
 
@@ -32,13 +32,13 @@ class CatchCheck extends BaseCheck {
 	 * run
 	 *
 	 * @param string         $fileName The name of the file we are parsing
-	 * @param Node           $node     Instance of the Node
-	 * @param ClassLike|null $inside   Instance of the ClassLike (the class we are parsing) [optional]
-	 * @param Scope|null     $scope    Instance of the Scope (all variables in the current state) [optional]
+	 * @param Node           $node Instance of the Node
+	 * @param ClassLike|null $inside Instance of the ClassLike (the class we are parsing) [optional]
+	 * @param Scope|null     $scope Instance of the Scope (all variables in the current state) [optional]
 	 *
 	 * @return void
 	 */
-	public function run($fileName, Node $node, ClassLike $inside = null, Scope $scope = null) {
+	public function run(string $fileName, Node $node, ClassLike $inside = null, Scope $scope = null) {
 		if ($node instanceof Catch_) {
 			foreach ($node->types as $nameOb) {
 				$name = strtolower(strval($nameOb));

--- a/src/Checks/ClassConstantCheck.php
+++ b/src/Checks/ClassConstantCheck.php
@@ -27,7 +27,7 @@ class ClassConstantCheck extends BaseCheck {
 	 *
 	 * @return array
 	 */
-	public function getCheckNodeTypes() {
+	public function getCheckNodeTypes(): array {
 		return [ClassConstFetch::class];
 	}
 
@@ -65,14 +65,14 @@ class ClassConstantCheck extends BaseCheck {
 	 * run
 	 *
 	 * @param string         $fileName The name of the file we are parsing
-	 * @param Node           $node     Instance of the Node
-	 * @param ClassLike|null $inside   Instance of the ClassLike (the class we are parsing) [optional]
-	 * @param Scope|null     $scope    Instance of the Scope (all variables in the current state) [optional]
+	 * @param Node           $node Instance of the Node
+	 * @param ClassLike|null $inside Instance of the ClassLike (the class we are parsing) [optional]
+	 * @param Scope|null     $scope Instance of the Scope (all variables in the current state) [optional]
+	 * @return void
 	 * @guardrail-ignore Standard.Unknown.Property
 	 *
-	 * @return void
 	 */
-	public function run($fileName, Node $node, ClassLike $inside=null, Scope $scope=null) {
+	public function run(string $fileName, Node $node, ClassLike $inside=null, Scope $scope=null) {
 		if ($node instanceof ClassConstFetch) {
 			if ($node->class instanceof Name) {
 				$name = $node->class->toString();

--- a/src/Checks/ClassMethodStringCheck.php
+++ b/src/Checks/ClassMethodStringCheck.php
@@ -15,7 +15,7 @@ class ClassMethodStringCheck extends BaseCheck {
 	/**
 	 * @return string[]
 	 */
-	function getCheckNodeTypes() {
+	function getCheckNodeTypes(): array {
 		return [Node\Expr\BinaryOp\Concat::class];
 	}
 
@@ -25,12 +25,12 @@ class ClassMethodStringCheck extends BaseCheck {
 	 * is a method name, so we emit a different error that can be disabled if the user desires.
 	 *
 	 * @param string         $fileName -
-	 * @param Node           $node     -
-	 * @param ClassLike|null $inside   -
-	 * @param Scope|null     $scope    -
+	 * @param Node           $node -
+	 * @param ClassLike|null $inside -
+	 * @param Scope|null     $scope -
 	 * @return void
 	 */
-	public function run($fileName, Node $node, ClassLike $inside = null, Scope $scope = null) {
+	public function run(string $fileName, Node $node, ClassLike $inside = null, Scope $scope = null) {
 		assert($node instanceof Node\Expr\BinaryOp\Concat);
 
 		// Look for ClassName::class."@method"

--- a/src/Checks/ClassStoredAsVariableCheck.php
+++ b/src/Checks/ClassStoredAsVariableCheck.php
@@ -17,7 +17,7 @@ class ClassStoredAsVariableCheck extends BaseCheck {
 	 *
 	 * @return string[]
 	 */
-	function getCheckNodeTypes() {
+	function getCheckNodeTypes(): array {
 		return [String_::class];
 	}
 
@@ -25,13 +25,13 @@ class ClassStoredAsVariableCheck extends BaseCheck {
 	 * run
 	 *
 	 * @param string         $fileName The name of the file we are parsing
-	 * @param Node           $node     Instance of the Node
-	 * @param ClassLike|null $inside   Instance of the ClassLike (the class we are parsing) [optional]
-	 * @param Scope|null     $scope    Instance of the Scope (all variables in the current state) [optional]
+	 * @param Node           $node Instance of the Node
+	 * @param ClassLike|null $inside Instance of the ClassLike (the class we are parsing) [optional]
+	 * @param Scope|null     $scope Instance of the Scope (all variables in the current state) [optional]
 	 *
 	 * @return void
 	 */
-	public function run($fileName, Node $node, ClassLike $inside = null, Scope $scope = null) {
+	public function run(string $fileName, Node $node, ClassLike $inside = null, Scope $scope = null) {
 		// if it's a string and a valid PHP class name (including the slashes for namespaced classes)
 		if ($node instanceof String_ && preg_match('/^[a-zA-Z_\\x7f-\\xff][a-zA-Z0-9_\\x7f-\\xff]*$/', $node->value)) {
 			// full match

--- a/src/Checks/ConditionalAssignmentCheck.php
+++ b/src/Checks/ConditionalAssignmentCheck.php
@@ -22,7 +22,7 @@ class ConditionalAssignmentCheck extends BaseCheck {
 	 *
 	 * @return array
 	 */
-	public function getCheckNodeTypes() {
+	public function getCheckNodeTypes(): array {
 		return [Node\Stmt\If_::class];
 	}
 
@@ -30,13 +30,13 @@ class ConditionalAssignmentCheck extends BaseCheck {
 	 * run
 	 *
 	 * @param string         $fileName The name of the file we are parsing
-	 * @param Node           $node     Instance of the Node
-	 * @param ClassLike|null $inside   Instance of the ClassLike (the class we are parsing) [optional]
-	 * @param Scope|null     $scope    Instance of the Scope (all variables in the current state) [optional]
+	 * @param Node           $node Instance of the Node
+	 * @param ClassLike|null $inside Instance of the ClassLike (the class we are parsing) [optional]
+	 * @param Scope|null     $scope Instance of the Scope (all variables in the current state) [optional]
 	 *
 	 * @return void
 	 */
-	public function run($fileName, Node $node, ClassLike $inside = null, Scope $scope = null) {
+	public function run(string $fileName, Node $node, ClassLike $inside = null, Scope $scope = null) {
 		if ($node instanceof Node\Stmt\If_) {
 			$assignment = null;
 			ForEachNode::run([$node->cond], function($node) use (&$assignment) {

--- a/src/Checks/ConstructorCheck.php
+++ b/src/Checks/ConstructorCheck.php
@@ -27,7 +27,7 @@ class ConstructorCheck extends BaseCheck {
 	 *
 	 * @return array
 	 */
-	public function getCheckNodeTypes() {
+	public function getCheckNodeTypes(): array {
 		return [ClassMethod::class];
 	}
 
@@ -59,13 +59,13 @@ class ConstructorCheck extends BaseCheck {
 	 * run
 	 *
 	 * @param string         $fileName The name of the file we are parsing
-	 * @param Node           $node     Instance of the Node
-	 * @param ClassLike|null $inside   Instance of the ClassLike (the class we are parsing) [optional]
-	 * @param Scope|null     $scope    Instance of the Scope (all variables in the current state) [optional]
+	 * @param Node           $node Instance of the Node
+	 * @param ClassLike|null $inside Instance of the ClassLike (the class we are parsing) [optional]
+	 * @param Scope|null     $scope Instance of the Scope (all variables in the current state) [optional]
 	 *
 	 * @return void
 	 */
-	public function run($fileName, Node $node, ClassLike $inside = null, Scope $scope = null) {
+	public function run(string $fileName, Node $node, ClassLike $inside = null, Scope $scope = null) {
 		if ($node instanceof ClassMethod) {
 			if ($inside instanceof Class_) {
 				if (strcasecmp($node->name, "__construct") == 0 &&

--- a/src/Checks/CyclomaticComplexityCheck.php
+++ b/src/Checks/CyclomaticComplexityCheck.php
@@ -51,14 +51,20 @@ class CyclomaticComplexityCheck extends BaseCheck {
 	 * @return void
 	 */
 	function checkStatements($fileName, $name, Node $node, array $statements) {
-		$complexity = 1;
-		ForEachNode::run($statements, function (Node $node) use (&$complexity) {
-			if (self::isStatementBranch($node) || self::isExpressionBranch($node)) {
-				++$complexity;
+		$config = $this->doc->getEmitConfig($fileName, ErrorConstants::TYPE_METRICS_COMPLEXITY, $node->getLine());
+
+		if(is_array($config)) {
+			$maxComplexity = $config['MaxComplexity'] ?? 10;
+
+			$complexity = 1;
+			ForEachNode::run($statements, function (Node $node) use (&$complexity) {
+				if (self::isStatementBranch($node) || self::isExpressionBranch($node)) {
+					++$complexity;
+				}
+			});
+			if ($complexity > $maxComplexity) {
+				$this->emitError($fileName, $node, ErrorConstants::TYPE_METRICS_COMPLEXITY, "Method " . $name . " has a complexity of $complexity");
 			}
-		});
-		if ($complexity > 10) {
-			$this->emitError($fileName, $node, ErrorConstants::TYPE_METRICS_COMPLEXITY, "Method " . $name . " has a complexity of $complexity");
 		}
 	}
 

--- a/src/Checks/CyclomaticComplexityCheck.php
+++ b/src/Checks/CyclomaticComplexityCheck.php
@@ -11,7 +11,7 @@ class CyclomaticComplexityCheck extends BaseCheck {
 	/**
 	 * @return string[]
 	 */
-	function getCheckNodeTypes() {
+	function getCheckNodeTypes(): array {
 		return [Node\Stmt\ClassMethod::class, Node\Stmt\Function_::class];
 	}
 
@@ -65,12 +65,12 @@ class CyclomaticComplexityCheck extends BaseCheck {
 
 	/**
 	 * @param string                   $fileName The file being scanned
-	 * @param Node                     $node     The node being scanned
-	 * @param Node\Stmt\ClassLike|null $inside   The class we're inside
-	 * @param Scope|null               $scope    Any other relevant scope
+	 * @param Node                     $node The node being scanned
+	 * @param Node\Stmt\ClassLike|null $inside The class we're inside
+	 * @param Scope|null               $scope Any other relevant scope
 	 * @return void
 	 */
-	function run($fileName, Node $node, Node\Stmt\ClassLike $inside = null, Scope $scope = null) {
+	function run(string $fileName, Node $node, Node\Stmt\ClassLike $inside = null, Scope $scope = null) {
 		if ($node->stmts) {
 			if ($node instanceof Node\Stmt\ClassMethod) {
 				$this->checkStatements($fileName, $node->name, $node, $node->stmts);

--- a/src/Checks/DefinedConstantCheck.php
+++ b/src/Checks/DefinedConstantCheck.php
@@ -114,7 +114,7 @@ class DefinedConstantCheck extends BaseCheck {
 	 *
 	 * @return array
 	 */
-	public function getCheckNodeTypes() {
+	public function getCheckNodeTypes(): array {
 		return [ConstFetch::class];
 	}
 
@@ -174,13 +174,13 @@ class DefinedConstantCheck extends BaseCheck {
 	 * run
 	 *
 	 * @param string         $fileName The name of the file we are parsing
-	 * @param Node           $node     Instance of the Node
-	 * @param ClassLike|null $inside   Instance of the ClassLike (the class we are parsing) [optional]
-	 * @param Scope|null     $scope    Instance of the Scope (all variables in the current state) [optional]
+	 * @param Node           $node Instance of the Node
+	 * @param ClassLike|null $inside Instance of the ClassLike (the class we are parsing) [optional]
+	 * @param Scope|null     $scope Instance of the Scope (all variables in the current state) [optional]
 	 *
 	 * @return void
 	 */
-	public function run($fileName, Node $node, ClassLike $inside=null, Scope $scope=null) {
+	public function run(string $fileName, Node $node, ClassLike $inside=null, Scope $scope=null) {
 		if ($node instanceof ConstFetch) {
 			$namespacedName = $node->name->hasAttribute('namespacedName') ? $node->name->getAttribute('namespacedName')->toString() : "";
 			$name = $node->name->toString();

--- a/src/Checks/FunctionCallCheck.php
+++ b/src/Checks/FunctionCallCheck.php
@@ -34,7 +34,7 @@ class FunctionCallCheck extends CallCheck {
 	 *
 	 * @return array
 	 */
-	public function getCheckNodeTypes() {
+	public function getCheckNodeTypes(): array {
 		return [FuncCall::class, Node\Expr\Eval_::class];
 	}
 
@@ -65,13 +65,13 @@ class FunctionCallCheck extends CallCheck {
 	 * run
 	 *
 	 * @param string         $fileName The name of the file we are parsing
-	 * @param Node           $node     Instance of the Node
-	 * @param ClassLike|null $inside   Instance of the ClassLike (the class we are parsing) [optional]
-	 * @param Scope|null     $scope    Instance of the Scope (all variables in the current state) [optional]
+	 * @param Node           $node Instance of the Node
+	 * @param ClassLike|null $inside Instance of the ClassLike (the class we are parsing) [optional]
+	 * @param Scope|null     $scope Instance of the Scope (all variables in the current state) [optional]
 	 *
 	 * @return void
 	 */
-	public function run($fileName, Node $node, ClassLike $inside = null, Scope $scope = null) {
+	public function run(string $fileName, Node $node, ClassLike $inside = null, Scope $scope = null) {
 
 		if ($node instanceof Node\Expr\Eval_) {
 			$this->emitError($fileName, $node, ErrorConstants::TYPE_SECURITY_DANGEROUS, "Call to dangerous function eval()");

--- a/src/Checks/GotoCheck.php
+++ b/src/Checks/GotoCheck.php
@@ -22,7 +22,7 @@ class GotoCheck extends BaseCheck {
 	 *
 	 * @return array
 	 */
-	public function getCheckNodeTypes() {
+	public function getCheckNodeTypes(): array {
 		return [ Goto_::class ];
 	}
 
@@ -30,13 +30,13 @@ class GotoCheck extends BaseCheck {
 	 * run
 	 *
 	 * @param string         $fileName The name of the file we are parsing
-	 * @param Node           $node     Instance of the Node
-	 * @param ClassLike|null $inside   Instance of the ClassLike (the class we are parsing) [optional]
-	 * @param Scope|null     $scope    Instance of the Scope (all variables in the current state) [optional]
+	 * @param Node           $node Instance of the Node
+	 * @param ClassLike|null $inside Instance of the ClassLike (the class we are parsing) [optional]
+	 * @param Scope|null     $scope Instance of the Scope (all variables in the current state) [optional]
 	 *
 	 * @return void
 	 */
-	public function run($fileName, Node $node, ClassLike $inside = null, Scope $scope = null) {
+	public function run(string $fileName, Node $node, ClassLike $inside = null, Scope $scope = null) {
 		$this->emitError($fileName, $node, ErrorConstants::TYPE_GOTO, "Usage of goto command");
 	}
 }

--- a/src/Checks/ImagickCheck.php
+++ b/src/Checks/ImagickCheck.php
@@ -12,11 +12,11 @@ class ImagickCheck extends BaseCheck
 	/**
 	 * @return string[]
 	 */
-	function getCheckNodeTypes() {
+	function getCheckNodeTypes():array {
 		return [ Node\Expr\New_::class ];
 	}
 
-	function run($fileName, Node $node, Node\Stmt\ClassLike $inside = null, Scope $scope = null) {
+	function run(string $fileName, Node $node, Node\Stmt\ClassLike $inside = null, Scope $scope = null) {
 		if ($node instanceof Node\Expr\New_) {
 			if($node->class instanceof Node\Name && strcasecmp($node->class->toString(), "imagick")==0) {
 				$this->emitError($fileName, $node, ErrorConstants::TYPE_UNSAFE_IMAGICK, "Attempt to Instantiate unsafe class: ".$node->class->toString());

--- a/src/Checks/InstanceOfCheck.php
+++ b/src/Checks/InstanceOfCheck.php
@@ -23,7 +23,7 @@ class InstanceOfCheck extends BaseCheck {
 	 *
 	 * @return array
 	 */
-	public function getCheckNodeTypes() {
+	public function getCheckNodeTypes(): array {
 		return [Instanceof_::class];
 	}
 
@@ -31,13 +31,13 @@ class InstanceOfCheck extends BaseCheck {
 	 * run
 	 *
 	 * @param string         $fileName The name of the file we are parsing
-	 * @param Node           $node     Instance of the Node
-	 * @param ClassLike|null $inside   Instance of the ClassLike (the class we are parsing) [optional]
-	 * @param Scope|null     $scope    Instance of the Scope (all variables in the current state) [optional]
+	 * @param Node           $node Instance of the Node
+	 * @param ClassLike|null $inside Instance of the ClassLike (the class we are parsing) [optional]
+	 * @param Scope|null     $scope Instance of the Scope (all variables in the current state) [optional]
 	 *
 	 * @return void
 	 */
-	public function run($fileName, Node $node, ClassLike $inside=null, Scope $scope=null) {
+	public function run(string $fileName, Node $node, ClassLike $inside=null, Scope $scope=null) {
 		if ($node instanceof Instanceof_) {
 			if ($node->class instanceof Name) {
 				$name = $node->class->toString();

--- a/src/Checks/InstantiationCheck.php
+++ b/src/Checks/InstantiationCheck.php
@@ -25,7 +25,7 @@ class InstantiationCheck extends MethodCall {
 	 *
 	 * @return array
 	 */
-	public function getCheckNodeTypes() {
+	public function getCheckNodeTypes(): array {
 		return [New_::class];
 	}
 
@@ -35,13 +35,13 @@ class InstantiationCheck extends MethodCall {
 	 * @override
 	 *
 	 * @param string         $fileName The name of the file we are parsing
-	 * @param Node           $node     Instance of the Node
-	 * @param ClassLike|null $inside   Instance of the ClassLike (the class we are parsing) [optional]
-	 * @param Scope|null     $scope    Instance of the Scope (all variables in the current state) [optional]
+	 * @param Node           $node Instance of the Node
+	 * @param ClassLike|null $inside Instance of the ClassLike (the class we are parsing) [optional]
+	 * @param Scope|null     $scope Instance of the Scope (all variables in the current state) [optional]
 	 *
 	 * @return void
 	 */
-	public function run($fileName, Node $node, ClassLike $inside=null, Scope $scope=null) {
+	public function run(string $fileName, Node $node, ClassLike $inside=null, Scope $scope=null) {
 		if ($node instanceof New_) {
 			if ($node->class instanceof Name) {
 				$name = $node->class->toString();

--- a/src/Checks/InterfaceCheck.php
+++ b/src/Checks/InterfaceCheck.php
@@ -38,7 +38,7 @@ class InterfaceCheck extends BaseCheck {
 	 *
 	 * @return array
 	 */
-	public function getCheckNodeTypes() {
+	public function getCheckNodeTypes(): array {
 		return [Class_::class];
 	}
 
@@ -132,13 +132,13 @@ class InterfaceCheck extends BaseCheck {
 	 * run
 	 *
 	 * @param string         $fileName The name of the file we are parsing
-	 * @param Node           $node     Instance of the Node
-	 * @param ClassLike|null $inside   Instance of the ClassLike (the class we are parsing) [optional]
-	 * @param Scope|null     $scope    Instance of the Scope (all variables in the current state) [optional]
+	 * @param Node           $node Instance of the Node
+	 * @param ClassLike|null $inside Instance of the ClassLike (the class we are parsing) [optional]
+	 * @param Scope|null     $scope Instance of the Scope (all variables in the current state) [optional]
 	 *
 	 * @return void
 	 */
-	public function run($fileName, Node $node, ClassLike $inside=null, Scope $scope=null) {
+	public function run(string $fileName, Node $node, ClassLike $inside=null, Scope $scope=null) {
 		if ($node instanceof Class_) {
 			if ($node->implements) {
 				$this->processNodeImplements($fileName, $node);

--- a/src/Checks/MethodCall.php
+++ b/src/Checks/MethodCall.php
@@ -44,23 +44,22 @@ class MethodCall extends CallCheck {
 	 *
 	 * @return array
 	 */
-	public function getCheckNodeTypes() {
+	public function getCheckNodeTypes(): array {
 		return [\PhpParser\Node\Expr\MethodCall::class];
 	}
-
 
 
 	/**
 	 * run
 	 *
 	 * @param string         $fileName The name of the file we are parsing
-	 * @param Node           $node     Instance of the Node
-	 * @param ClassLike|null $inside   Instance of the ClassLike (the class we are parsing) [optional]
-	 * @param Scope|null     $scope    Instance of the Scope (all variables in the current state) [optional]
+	 * @param Node           $node Instance of the Node
+	 * @param ClassLike|null $inside Instance of the ClassLike (the class we are parsing) [optional]
+	 * @param Scope|null     $scope Instance of the Scope (all variables in the current state) [optional]
 	 *
 	 * @return mixed
 	 */
-	public function run($fileName, Node $node, ClassLike $inside=null, Scope $scope=null) {
+	public function run(string $fileName, Node $node, ClassLike $inside=null, Scope $scope=null) {
 		static $checkable = 0, $uncheckable = 0;
 		if ($node instanceof Expr\MethodCall) {
 			if ($inside instanceof Trait_) {

--- a/src/Checks/ParamTypesCheck.php
+++ b/src/Checks/ParamTypesCheck.php
@@ -28,7 +28,7 @@ class ParamTypesCheck extends BaseCheck {
 	 *
 	 * @return array
 	 */
-	public function getCheckNodeTypes() {
+	public function getCheckNodeTypes(): array {
 		return [ ClassMethod::class, Function_::class, Closure::class];
 	}
 
@@ -67,13 +67,13 @@ class ParamTypesCheck extends BaseCheck {
 	 * run
 	 *
 	 * @param string         $fileName The name of the file we are parsing
-	 * @param Node           $node     Instance of the Node
-	 * @param ClassLike|null $inside   Instance of the ClassLike (the class we are parsing) [optional]
-	 * @param Scope|null     $scope    Instance of the Scope (all variables in the current state) [optional]
+	 * @param Node           $node Instance of the Node
+	 * @param ClassLike|null $inside Instance of the ClassLike (the class we are parsing) [optional]
+	 * @param Scope|null     $scope Instance of the Scope (all variables in the current state) [optional]
 	 *
 	 * @return void
 	 */
-	public function run($fileName, Node $node, ClassLike $inside=null, Scope $scope=null) {
+	public function run(string $fileName, Node $node, ClassLike $inside=null, Scope $scope=null) {
 
 		if ($node instanceof Function_) {
 			$this->checkForNestedFunction($fileName, $node, $inside, $scope);

--- a/src/Checks/PropertyFetchCheck.php
+++ b/src/Checks/PropertyFetchCheck.php
@@ -44,7 +44,7 @@ class PropertyFetchCheck extends BaseCheck {
 	 *
 	 * @return array
 	 */
-	public function getCheckNodeTypes() {
+	public function getCheckNodeTypes(): array {
 		return [ PropertyFetch::class];
 	}
 
@@ -52,13 +52,13 @@ class PropertyFetchCheck extends BaseCheck {
 	 * run
 	 *
 	 * @param string         $fileName The name of the file we are parsing
-	 * @param Node           $node     Instance of the Node
-	 * @param ClassLike|null $inside   Instance of the ClassLike (the class we are parsing) [optional]
-	 * @param Scope|null     $scope    Instance of the Scope (all variables in the current state) [optional]
+	 * @param Node           $node Instance of the Node
+	 * @param ClassLike|null $inside Instance of the ClassLike (the class we are parsing) [optional]
+	 * @param Scope|null     $scope Instance of the Scope (all variables in the current state) [optional]
 	 *
 	 * @return void
 	 */
-	public function run($fileName, Node $node, ClassLike $inside=null, Scope $scope=null) {
+	public function run(string $fileName, Node $node, ClassLike $inside=null, Scope $scope=null) {
 		if ($node instanceof PropertyFetch) {
 			list($type, $attributes) = $this->typeInferer->inferType($inside, $node->var, $scope);
 			if ($type && $type[0] != '!' && !$this->symbolTable->ignoreType($type)) {

--- a/src/Checks/PropertyStoreCheck.php
+++ b/src/Checks/PropertyStoreCheck.php
@@ -44,7 +44,7 @@ class PropertyStoreCheck extends BaseCheck {
 	 *
 	 * @return array
 	 */
-	public function getCheckNodeTypes() {
+	public function getCheckNodeTypes(): array {
 		return [ Node\Expr\Assign::class ];
 	}
 
@@ -52,13 +52,13 @@ class PropertyStoreCheck extends BaseCheck {
 	 * run
 	 *
 	 * @param string         $fileName The name of the file we are parsing
-	 * @param Node           $node     Instance of the Node
-	 * @param ClassLike|null $inside   Instance of the ClassLike (the class we are parsing) [optional]
-	 * @param Scope|null     $scope    Instance of the Scope (all variables in the current state) [optional]
+	 * @param Node           $node Instance of the Node
+	 * @param ClassLike|null $inside Instance of the ClassLike (the class we are parsing) [optional]
+	 * @param Scope|null     $scope Instance of the Scope (all variables in the current state) [optional]
 	 *
 	 * @return void
 	 */
-	public function run($fileName, Node $node, ClassLike $inside=null, Scope $scope=null) {
+	public function run(string $fileName, Node $node, ClassLike $inside=null, Scope $scope=null) {
 		if ($node instanceof Node\Expr\Assign && $node->var instanceof PropertyFetch && $node->var->name instanceof Node\Identifier) {
 			list($leftType, $leftAttributes) = $this->typeInferer->inferType($inside, $node->var, $scope);
 			list($rightType, $rightAttributes) = $this->typeInferer->inferType($inside, $node->expr, $scope);
@@ -68,7 +68,9 @@ class PropertyStoreCheck extends BaseCheck {
 						$this->emitError($fileName, $node, ErrorConstants::TYPE_ASSIGN_MISMATCH, "Type mismatch can not assign $rightType into a $leftType");
 					}
 				} else if (!$this->isArray($leftType) && $this->isArray($rightType)) {
-					$this->emitError($fileName, $node, ErrorConstants::TYPE_ASSIGN_MISMATCH, "Type mismatch can not assign $rightType into a $leftType");
+					$leftStr = Scope::nameFromConst($leftType);
+					$rightStr = Scope::nameFromConst($rightType);
+					$this->emitError($fileName, $node, ErrorConstants::TYPE_ASSIGN_MISMATCH, "Type mismatch can not assign $rightStr into a $leftStr");
 				} else {
 					//at least one of the parameters is scalar
 					if ($leftType[0] == '!') {

--- a/src/Checks/Psr4Check.php
+++ b/src/Checks/Psr4Check.php
@@ -29,7 +29,7 @@ class Psr4Check extends BaseCheck {
 	/**
 	 * @return string[]
 	 */
-	function getCheckNodeTypes() {
+	function getCheckNodeTypes(): array {
 		return [Node\Stmt\Class_::class, Node\Stmt\Interface_::class, Node\Stmt\Trait_::class];
 	}
 
@@ -49,13 +49,13 @@ class Psr4Check extends BaseCheck {
 
 	/**
 	 * @param string                   $fileName Current filename
-	 * @param Node                     $node     Current node
-	 * @param Node\Stmt\ClassLike|null $inside   Current class
-	 * @param Scope|null               $scope    Any relevant scope
+	 * @param Node                     $node Current node
+	 * @param Node\Stmt\ClassLike|null $inside Current class
+	 * @param Scope|null               $scope Any relevant scope
 	 * @return void
 	 * @guardrail-ignore Standard.Unknown.Property
 	 */
-	function run($fileName, Node $node, Node\Stmt\ClassLike $inside = null, Scope $scope = null) {
+	function run(string $fileName, Node $node, Node\Stmt\ClassLike $inside = null, Scope $scope = null) {
 		$name = "";
 		$fullName = "";
 		if ($node instanceof Node\Stmt\Class_) {

--- a/src/Checks/ReturnCheck.php
+++ b/src/Checks/ReturnCheck.php
@@ -42,7 +42,7 @@ class ReturnCheck extends BaseCheck {
 	 *
 	 * @return array
 	 */
-	public function getCheckNodeTypes() {
+	public function getCheckNodeTypes(): array {
 		return [ Return_::class ];
 	}
 
@@ -50,13 +50,13 @@ class ReturnCheck extends BaseCheck {
 	 * run
 	 *
 	 * @param string         $fileName The name of the file we are parsing
-	 * @param Node           $node     Instance of the Node
-	 * @param ClassLike|null $inside   Instance of the ClassLike (the class we are parsing) [optional]
-	 * @param Scope|null     $scope    Instance of the Scope (all variables in the current state) [optional]
+	 * @param Node           $node Instance of the Node
+	 * @param ClassLike|null $inside Instance of the ClassLike (the class we are parsing) [optional]
+	 * @param Scope|null     $scope Instance of the Scope (all variables in the current state) [optional]
 	 *
 	 * @return void
 	 */
-	public function run($fileName, Node $node, ClassLike $inside = null, Scope $scope = null) {
+	public function run(string $fileName, Node $node, ClassLike $inside = null, Scope $scope = null) {
 		if ($node instanceof Return_) {
 			$insideFunc = $scope->getInsideFunction();
 

--- a/src/Checks/SplatCheck.php
+++ b/src/Checks/SplatCheck.php
@@ -25,7 +25,7 @@ class SplatCheck extends BaseCheck {
 	 *
 	 * @return array
 	 */
-	public function getCheckNodeTypes() {
+	public function getCheckNodeTypes(): array {
 		return [ ArrayItem::class ];
 	}
 
@@ -33,13 +33,13 @@ class SplatCheck extends BaseCheck {
 	 * run
 	 *
 	 * @param string                   $fileName The name of the file we are parsing
-	 * @param Node                     $node     Instance of the Node
-	 * @param Node\Stmt\ClassLike|null $inside   Instance of the ClassLike (the class we are parsing) [optional]
-	 * @param Scope|null               $scope    Instance of the Scope (all variables in the current state) [optional]
+	 * @param Node                     $node Instance of the Node
+	 * @param Node\Stmt\ClassLike|null $inside Instance of the ClassLike (the class we are parsing) [optional]
+	 * @param Scope|null               $scope Instance of the Scope (all variables in the current state) [optional]
 	 *
 	 * @return void
 	 */
-	public function run($fileName, Node $node, Node\Stmt\ClassLike $inside=null, Scope $scope = null) {
+	public function run(string $fileName, Node $node, Node\Stmt\ClassLike $inside=null, Scope $scope = null) {
 		if ($node instanceof ArrayItem) {
 			if ($node->unpack) {
 				list($type) = $this->typeInferer->inferType($inside, $node->value, $scope);

--- a/src/Checks/StaticCallCheck.php
+++ b/src/Checks/StaticCallCheck.php
@@ -25,7 +25,7 @@ class StaticCallCheck extends BaseCheck {
 	 *
 	 * @return array
 	 */
-	public function getCheckNodeTypes() {
+	public function getCheckNodeTypes(): array {
 		return [StaticCall::class];
 	}
 
@@ -33,13 +33,13 @@ class StaticCallCheck extends BaseCheck {
 	 * run
 	 *
 	 * @param string         $fileName The name of the file we are parsing
-	 * @param Node           $node     Instance of the Node
-	 * @param ClassLike|null $inside   Instance of the ClassLike (the class we are parsing) [optional]
-	 * @param Scope|null     $scope    Instance of the Scope (all variables in the current state) [optional]
+	 * @param Node           $node Instance of the Node
+	 * @param ClassLike|null $inside Instance of the ClassLike (the class we are parsing) [optional]
+	 * @param Scope|null     $scope Instance of the Scope (all variables in the current state) [optional]
 	 *
 	 * @return void
 	 */
-	public function run($fileName, Node $node, ClassLike $inside=null, Scope $scope = null) {
+	public function run(string $fileName, Node $node, ClassLike $inside=null, Scope $scope = null) {
 		if ($node instanceof StaticCall) {
 			$this->checkStaticCall($fileName, $node, $inside, $scope);
 		}

--- a/src/Checks/StaticPropertyFetchCheck.php
+++ b/src/Checks/StaticPropertyFetchCheck.php
@@ -42,7 +42,7 @@ class StaticPropertyFetchCheck extends BaseCheck {
 	 *
 	 * @return array
 	 */
-	public function getCheckNodeTypes() {
+	public function getCheckNodeTypes(): array {
 		return [ Node\Expr\StaticPropertyFetch::class ];
 	}
 
@@ -50,13 +50,13 @@ class StaticPropertyFetchCheck extends BaseCheck {
 	 * run
 	 *
 	 * @param string         $fileName The name of the file we are parsing
-	 * @param Node           $node     Instance of the Node
-	 * @param ClassLike|null $inside   Instance of the ClassLike (the class we are parsing) [optional]
-	 * @param Scope|null     $scope    Instance of the Scope (all variables in the current state) [optional]
+	 * @param Node           $node Instance of the Node
+	 * @param ClassLike|null $inside Instance of the ClassLike (the class we are parsing) [optional]
+	 * @param Scope|null     $scope Instance of the Scope (all variables in the current state) [optional]
 	 *
 	 * @return void
 	 */
-	public function run($fileName, Node $node, ClassLike $inside=null, Scope $scope=null) {
+	public function run(string $fileName, Node $node, ClassLike $inside=null, Scope $scope=null) {
 		if ($node instanceof Node\Expr\StaticPropertyFetch) {
 			$class = $node->class;
 			if ($class == "self" || $class == "static") {

--- a/src/Checks/SwitchCheck.php
+++ b/src/Checks/SwitchCheck.php
@@ -23,7 +23,7 @@ class SwitchCheck extends BaseCheck {
 	 *
 	 * @return array
 	 */
-	public function getCheckNodeTypes() {
+	public function getCheckNodeTypes(): array {
 		return [ Switch_::class ];
 	}
 
@@ -56,13 +56,13 @@ class SwitchCheck extends BaseCheck {
 	 * run
 	 *
 	 * @param string         $fileName The name of the file we are parsing
-	 * @param Node           $node     Instance of the Node
-	 * @param ClassLike|null $inside   Instance of the ClassLike (the class we are parsing) [optional]
-	 * @param Scope|null     $scope    Instance of the Scope (all variables in the current state) [optional]
+	 * @param Node           $node Instance of the Node
+	 * @param ClassLike|null $inside Instance of the ClassLike (the class we are parsing) [optional]
+	 * @param Scope|null     $scope Instance of the Scope (all variables in the current state) [optional]
 	 *
 	 * @return void
 	 */
-	public function run($fileName, Node $node, ClassLike $inside=null, Scope $scope=null) {
+	public function run(string $fileName, Node $node, ClassLike $inside=null, Scope $scope=null) {
 		if ($node instanceof Switch_) {
 			if (!Util::allBranchesExit([$node]) && is_array($node->cases)) {
 				$nextError = null;

--- a/src/Checks/UndefinedVariableCheck.php
+++ b/src/Checks/UndefinedVariableCheck.php
@@ -23,7 +23,7 @@ class UndefinedVariableCheck extends BaseCheck {
 	 *
 	 * @return array
 	 */
-	public function getCheckNodeTypes() {
+	public function getCheckNodeTypes(): array {
 		return [Variable::class];
 	}
 
@@ -31,13 +31,13 @@ class UndefinedVariableCheck extends BaseCheck {
 	 * run
 	 *
 	 * @param string         $fileName The name of the file we are parsing
-	 * @param Node           $node     Instance of the Node
-	 * @param ClassLike|null $inside   Instance of the ClassLike (the class we are parsing) [optional]
-	 * @param Scope|null     $scope    Instance of the Scope (all variables in the current state) [optional]
+	 * @param Node           $node Instance of the Node
+	 * @param ClassLike|null $inside Instance of the ClassLike (the class we are parsing) [optional]
+	 * @param Scope|null     $scope Instance of the Scope (all variables in the current state) [optional]
 	 *
 	 * @return void
 	 */
-	public function run($fileName, Node $node, ClassLike $inside=null, Scope $scope=null) {
+	public function run(string $fileName, Node $node, ClassLike $inside=null, Scope $scope=null) {
 		if ($node instanceof Variable) {
 			if ($node->name instanceof Expr) {
 				$this->emitError($fileName, $node, ErrorConstants::TYPE_VARIABLE_VARIABLE, "Variable variable detected");

--- a/src/Checks/UnreachableCodeCheck.php
+++ b/src/Checks/UnreachableCodeCheck.php
@@ -20,7 +20,7 @@ class UnreachableCodeCheck extends BaseCheck {
 	 *
 	 * @return string[]
 	 */
-	function getCheckNodeTypes() {
+	function getCheckNodeTypes(): array {
 		return [ Function_::class, ClassMethod::class ];
 	}
 
@@ -28,13 +28,13 @@ class UnreachableCodeCheck extends BaseCheck {
 	 * run
 	 *
 	 * @param string         $fileName The name of the file we are parsing
-	 * @param Node           $node     Instance of the Node
-	 * @param ClassLike|null $inside   Instance of the ClassLike (the class we are parsing) [optional]
-	 * @param Scope|null     $scope    Instance of the Scope (all variables in the current state) [optional]
+	 * @param Node           $node Instance of the Node
+	 * @param ClassLike|null $inside Instance of the ClassLike (the class we are parsing) [optional]
+	 * @param Scope|null     $scope Instance of the Scope (all variables in the current state) [optional]
 	 *
 	 * @return void
 	 */
-	public function run($fileName, Node $node, ClassLike $inside = null, Scope $scope = null) {
+	public function run(string $fileName, Node $node, ClassLike $inside = null, Scope $scope = null) {
 		if ($node instanceof Function_ || $node instanceof ClassMethod) {
 			$statements = [];
 			if ($node instanceof FunctionLike) {

--- a/src/Checks/UnsafeSuperGlobalCheck.php
+++ b/src/Checks/UnsafeSuperGlobalCheck.php
@@ -12,11 +12,11 @@ class UnsafeSuperGlobalCheck extends BaseCheck {
 	/**
 	 * @return string[]
 	 */
-	function getCheckNodeTypes() {
+	function getCheckNodeTypes():array {
 		return [Node\Expr\Variable::class];
 	}
 
-	function run($fileName, Node $node, Node\Stmt\ClassLike $inside = null, Scope $scope = null) {
+	function run(string $fileName, Node $node, Node\Stmt\ClassLike $inside = null, Scope $scope = null) {
 		if ($node instanceof Node\Expr\Variable && $this->isUnsafeSuperGlobal($node->name)) {
 			$this->emitError(
 				$fileName,

--- a/src/Checks/UnusedPrivateMemberVariableCheck.php
+++ b/src/Checks/UnusedPrivateMemberVariableCheck.php
@@ -40,7 +40,7 @@ class UnusedPrivateMemberVariableCheck extends BaseCheck {
 	 *
 	 * @return string[]
 	 */
-	function getCheckNodeTypes() {
+	function getCheckNodeTypes(): array {
 		return [Class_::class];
 	}
 
@@ -48,13 +48,13 @@ class UnusedPrivateMemberVariableCheck extends BaseCheck {
 	 * run
 	 *
 	 * @param string         $fileName The name of the file we are parsing
-	 * @param Node           $node     Instance of the Node
-	 * @param ClassLike|null $inside   Instance of the ClassLike (the class we are parsing) [optional]
-	 * @param Scope|null     $scope    Instance of the Scope (all variables in the current state) [optional]
+	 * @param Node           $node Instance of the Node
+	 * @param ClassLike|null $inside Instance of the ClassLike (the class we are parsing) [optional]
+	 * @param Scope|null     $scope Instance of the Scope (all variables in the current state) [optional]
 	 *
 	 * @return void
 	 */
-	public function run($fileName, Node $node, ClassLike $inside = null, Scope $scope = null) {
+	public function run(string $fileName, Node $node, ClassLike $inside = null, Scope $scope = null) {
 		if ($node instanceof Class_) {
 			$props = [];
 

--- a/src/Checks/UseStatementCaseCheck.php
+++ b/src/Checks/UseStatementCaseCheck.php
@@ -34,7 +34,7 @@ class UseStatementCaseCheck extends BaseCheck {
 		$type = $useNode->name;
 		$typeStr = $type->toString();
 		/** @var AbstractionClass */
-		$className = $this->symbolTable->getOriginalName(SymbolTable::TYPE_CLASS, $typeStr) ?? $this->symbolTable->getOriginalNAme(SymbolTable::TYPE_INTERFACE, $typeStr);
+		$className = $this->symbolTable->getOriginalName(SymbolTable::TYPE_CLASS, $typeStr) ?? $this->symbolTable->getOriginalName(SymbolTable::TYPE_INTERFACE, $typeStr);
 
 		if ($className && $type->toString() !== $className) {
 			$this->emitError($fileName, $useNode, ErrorConstants::TYPE_USE_CASE_SENSITIVE, "Use statement must use the same case as the class declaration: " . $type->toString() . ' !== ' . $className);

--- a/src/Checks/UseStatementCaseCheck.php
+++ b/src/Checks/UseStatementCaseCheck.php
@@ -32,8 +32,9 @@ class UseStatementCaseCheck extends BaseCheck {
 
 	function verifyCaseOfUseStatement(UseUse $useNode, string $fileName) {
 		$type = $useNode->name;
+		$typeStr = $type->toString();
 		/** @var AbstractionClass */
-		$className = $this->symbolTable->getOriginalName(SymbolTable::TYPE_CLASS) ?? $this->symbolTable->getOriginalNAme(SymbolTable::TYPE_INTERFACE);
+		$className = $this->symbolTable->getOriginalName(SymbolTable::TYPE_CLASS, $typeStr) ?? $this->symbolTable->getOriginalNAme(SymbolTable::TYPE_INTERFACE, $typeStr);
 
 		if ($className && $type->toString() !== $className) {
 			$this->emitError($fileName, $useNode, ErrorConstants::TYPE_USE_CASE_SENSITIVE, "Use statement must use the same case as the class declaration: " . $type->toString() . ' !== ' . $className);

--- a/src/Checks/UseStatementCaseCheck.php
+++ b/src/Checks/UseStatementCaseCheck.php
@@ -2,6 +2,7 @@
 
 use BambooHR\Guardrail\Abstractions\ClassAbstraction as AbstractionClass;
 use BambooHR\Guardrail\Scope;
+use BambooHR\Guardrail\SymbolTable\SymbolTable;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Use_;
 use PhpParser\Node\Stmt\UseUse;
@@ -10,11 +11,11 @@ class UseStatementCaseCheck extends BaseCheck {
 	/**
 	 * @return string[]
 	 */
-	function getCheckNodeTypes() {
+	function getCheckNodeTypes():array {
 		return [ Node\Stmt\Use_::class ];
 	}
 
-	function run($fileName, Node $node, Node\Stmt\ClassLike $inside = null, Scope $scope = null) {
+	function run(string $fileName, Node $node, Node\Stmt\ClassLike $inside = null, Scope $scope = null) {
 		if ($node instanceof Node\Stmt\Use_ && ($node->type == Use_::TYPE_NORMAL)) {
 			foreach ($node->uses as $useNode) {
 				$this->verifyCaseOfUseStatement($useNode, $fileName);
@@ -32,9 +33,10 @@ class UseStatementCaseCheck extends BaseCheck {
 	function verifyCaseOfUseStatement(UseUse $useNode, string $fileName) {
 		$type = $useNode->name;
 		/** @var AbstractionClass */
-		$class = $this->symbolTable->getAbstractedClass(strtolower($type));
-		if ($class && $type->toString() !== $class->getName()) {
-			$this->emitError($fileName, $useNode, ErrorConstants::TYPE_USE_CASE_SENSITIVE, "Use statement must use the same case as the class declaration: " . $type->toString() . ' !== ' . $class->getName());
+		$className = $this->symbolTable->getOriginalName(SymbolTable::TYPE_CLASS) ?? $this->symbolTable->getOriginalNAme(SymbolTable::TYPE_INTERFACE);
+
+		if ($className && $type->toString() !== $className) {
+			$this->emitError($fileName, $useNode, ErrorConstants::TYPE_USE_CASE_SENSITIVE, "Use statement must use the same case as the class declaration: " . $type->toString() . ' !== ' . $className);
 		}
 	}
 }

--- a/src/CommandLineRunner.php
+++ b/src/CommandLineRunner.php
@@ -73,17 +73,13 @@ where: -p #/#                 = Define the number of partitions and the current 
 			exit(1);
 		}
 
-		if (!extension_loaded("pdo_sqlite") || !extension_loaded("sqlite3")) {
-			echo "Guardrail requires the PDO Sqlite extension, which is not loaded.\n";
-			exit(1);
-		}
-
 		try {
 			$config = new Config($argv);
 		} catch (InvalidConfigException $exception) {
 			$this->usage();
 			exit(1);
 		}
+
 
 		if ($config->getOutputFormat() == "text") {
 			$output = new \BambooHR\Guardrail\Output\ConsoleOutput($config);

--- a/src/CommandLineRunner.php
+++ b/src/CommandLineRunner.php
@@ -79,8 +79,7 @@ where: -p #/#                 = Define the number of partitions and the current 
 			$this->usage();
 			exit(1);
 		}
-
-
+		
 		if ($config->getOutputFormat() == "text") {
 			$output = new \BambooHR\Guardrail\Output\ConsoleOutput($config);
 		} else if ($config->getOutputFormat() == "counts") {

--- a/src/CommandLineRunner.php
+++ b/src/CommandLineRunner.php
@@ -79,7 +79,7 @@ where: -p #/#                 = Define the number of partitions and the current 
 			$this->usage();
 			exit(1);
 		}
-		
+
 		if ($config->getOutputFormat() == "text") {
 			$output = new \BambooHR\Guardrail\Output\ConsoleOutput($config);
 		} else if ($config->getOutputFormat() == "counts") {

--- a/src/Config.php
+++ b/src/Config.php
@@ -27,6 +27,7 @@ class Config {
 	private $processes = 1;
 
 	/** @var string Directory containing the config file.  All files are relative to this directory */
+	/** @var string Directory containing the config file.  All files are relative to this directory */
 	private $basePath = "";
 
 	/**
@@ -100,7 +101,7 @@ class Config {
 	/**
 	 * @return void
 	 */
-	private function loadConfigVars() {
+	private function loadConfigVars():void {
 		if (isset($this->config) && array_key_exists('options', $this->config) && is_array($this->config['options'])) {
 			foreach ($this->config['options'] as $key => $value) {
 				if ($value === true) {
@@ -179,7 +180,7 @@ class Config {
 	/**
 	 * @return array
 	 */
-	public function getPsrRoots() {
+	public function getPsrRoots():array {
 		if (isset($this->config) && array_key_exists('psr-roots', $this->config) && is_array($this->config['psr-roots'])) {
 			return $this->config['psr-roots'];
 		}
@@ -189,35 +190,35 @@ class Config {
 	/**
 	 * @return bool
 	 */
-	static function shouldUseDocBlockForProperties() {
+	static function shouldUseDocBlockForProperties():bool {
 		return self::$useDocBlockForProperties;
 	}
 
 	/**
 	 * @return bool
 	 */
-	static function shouldUseDocBlockForParameters() {
+	static function shouldUseDocBlockForParameters():bool {
 		return self::$useDocBlockForParameters;
 	}
 
 	/**
 	 * @return bool
 	 */
-	static function shouldUseDocBlockForReturnValues() {
+	static function shouldUseDocBlockForReturnValues():bool {
 		return self::$useDocBlockForReturnValue;
 	}
 
 	/**
 	 * @return bool
 	 */
-	static function shouldUseDocBlockForInlineVars() {
+	static function shouldUseDocBlockForInlineVars():bool {
 		return self::$useDocBlockForInlineVars;
 	}
 
 	/**
 	 * @return bool
 	 */
-	public function shouldOutputTimings() {
+	public function shouldOutputTimings():bool {
 		return $this->timings;
 	}
 
@@ -229,7 +230,7 @@ class Config {
 	 *
 	 * @return BaseCheck[]
 	 */
-	public function getPlugins(SymbolTable $index, OutputInterface $output) {
+	public function getPlugins(SymbolTable $index, OutputInterface $output):array {
 		$plugins = [];
 		if (isset($this->config['plugins']) && is_array($this->config['plugins'])) {
 			foreach ($this->config['plugins'] as $fileName) {
@@ -246,30 +247,24 @@ class Config {
 	 *
 	 * @return int
 	 */
-	public function getOutputLevel() {
+	public function getOutputLevel():int {
 		return $this->outputLevel;
 	}
 
 	/**
 	 * @return FilterInterface
 	 */
-	public function getFilter() {
+	public function getFilter():?FilterInterface {
 		return $this->filter;
 	}
 
-	/**
-	 * @return string
-	 */
-	public function getFilterFileName() {
-		return $this->filterFileName;
-	}
 
 	/**
 	 * showStandardTests
 	 *
 	 * @return void
 	 */
-	public function showStandardTests() {
+	public function showStandardTests():void {
 		echo "The following constants are supported:\n    " . implode("\n    ", ErrorConstants::getConstants()) . "\n";
 	}
 
@@ -391,7 +386,7 @@ class Config {
 	 *
 	 * @return int
 	 */
-	public function getProcessCount() {
+	public function getProcessCount():int {
 		return $this->processes;
 	}
 
@@ -409,7 +404,7 @@ class Config {
 	 *
 	 * @return bool
 	 */
-	public function hasFileList() {
+	public function hasFileList():bool {
 		return $this->fileList !== false;
 	}
 
@@ -445,7 +440,7 @@ class Config {
 	 *
 	 * @return int
 	 */
-	public function getPartitionNumber() {
+	public function getPartitionNumber():int {
 		return $this->partitionNumber;
 	}
 
@@ -454,7 +449,7 @@ class Config {
 	 *
 	 * @return string
 	 */
-	public function getBasePath() {
+	public function getBasePath():string {
 		return $this->basePath;
 	}
 
@@ -463,7 +458,7 @@ class Config {
 	 *
 	 * @return SymbolTable
 	 */
-	public function getSymbolTable() {
+	public function getSymbolTable():SymbolTable {
 		return $this->symbolTable;
 	}
 
@@ -472,7 +467,7 @@ class Config {
 	 *
 	 * @return bool
 	 */
-	public function shouldIndex() {
+	public function shouldIndex():bool {
 		return $this->forceIndex;
 	}
 
@@ -481,14 +476,14 @@ class Config {
 	 *
 	 * @return bool
 	 */
-	public function shouldAnalyze() {
+	public function shouldAnalyze():bool {
 		return $this->forceAnalysis;
 	}
 
 	/**
 	 * @return string
 	 */
-	public function getOutputFormat() {
+	public function getOutputFormat():string {
 		return $this->format;
 	}
 
@@ -497,7 +492,7 @@ class Config {
 	 *
 	 * @return string
 	 */
-	private function getSymbolTableFile() {
+	private function getSymbolTableFile():string {
 		return $this->basePath . "/" . $this->symbolTableFile .
 			($this->preferredTable == self::SQLITE_SYMBOL_TABLE ? ".sqlite3" : ".json");
 	}
@@ -507,7 +502,7 @@ class Config {
 	 *
 	 * @return bool
 	 */
-	public function shouldReindex() {
+	public function shouldReindex():bool {
 		return $this->reindex;
 	}
 
@@ -516,7 +511,7 @@ class Config {
 	 *
 	 * @return mixed|\string[]
 	 */
-	public function getEmitList() {
+	public function getEmitList():array {
 		return $this->emitList;
 	}
 
@@ -525,7 +520,7 @@ class Config {
 	 *
 	 * @return int
 	 */
-	public function processCount() {
+	public function processCount():int {
 		return $this->processes;
 	}
 
@@ -534,7 +529,7 @@ class Config {
 	 *
 	 * @return string
 	 */
-	public function getOutputFile() {
+	public function getOutputFile():string {
 		if ($this->partitions > 1) {
 			$lastPart = strrpos($this->outputFile, ".");
 			if ($lastPart > 0) {

--- a/src/NodeVisitors/ForEachNode.php
+++ b/src/NodeVisitors/ForEachNode.php
@@ -26,7 +26,7 @@ class ForEachNode extends NodeVisitorAbstract {
 	 *
 	 * @param string $callBack The callback
 	 */
-	public function __construct($callBack) {
+	public function __construct(callable $callBack) {
 		$this->callBack = $callBack;
 	}
 

--- a/src/NodeVisitors/StaticAnalyzer.php
+++ b/src/NodeVisitors/StaticAnalyzer.php
@@ -147,7 +147,6 @@ class StaticAnalyzer extends NodeVisitorAbstract {
 			new InstanceOfCheck($this->index, $output),
 			new CatchCheck($this->index, $output),
 			new ClassConstantCheck($this->index, $output),
-			// SLOW!!! new ClassStoredAsVariableCheck($this->index, $output),
 			new FunctionCallCheck($this->index, $output),
 			new MethodCall($this->index, $output),
 			new SwitchCheck($this->index, $output),
@@ -168,7 +167,7 @@ class StaticAnalyzer extends NodeVisitorAbstract {
 			new ImagickCheck($this->index, $output),
 			new UnsafeSuperGlobalCheck($this->index, $output),
 			new UseStatementCaseCheck($this->index, $output),
-			//new ClassStoredAsVariableCheck($this->index, $output)
+			// SLOW!!! new ClassStoredAsVariableCheck($this->index, $output)
 		];
 
 		$this->enterHooks = $this->buildClosures();

--- a/src/NodeVisitors/StaticAnalyzer.php
+++ b/src/NodeVisitors/StaticAnalyzer.php
@@ -144,6 +144,7 @@ class StaticAnalyzer extends NodeVisitorAbstract {
 			new InstanceOfCheck($this->index, $output),
 			new CatchCheck($this->index, $output),
 			new ClassConstantCheck($this->index, $output),
+			// SLOW!!! new ClassStoredAsVariableCheck($this->index, $output),
 			new FunctionCallCheck($this->index, $output),
 			new MethodCall($this->index, $output),
 			new SwitchCheck($this->index, $output),

--- a/src/Output/ConsoleOutput.php
+++ b/src/Output/ConsoleOutput.php
@@ -17,7 +17,7 @@ class ConsoleOutput extends XUnitOutput {
 	 * @param string $message    -
 	 * @return void
 	 */
-	public function emitError($className, $fileName, $lineNumber, $name, $message = "") {
+	public function emitError(string $className, string $fileName, int $lineNumber, string $name, string $message = "") {
 		if (!$this->shouldEmit($fileName, $name, $lineNumber)) {
 			return;
 		}

--- a/src/Output/CountsOutput.php
+++ b/src/Output/CountsOutput.php
@@ -17,7 +17,7 @@ class CountsOutput extends XUnitOutput {
 	 * @param string $message    -
 	 * @return void
 	 */
-	public function emitError($className, $fileName, $lineNumber, $name, $message = "") {
+	public function emitError(string $className, string $fileName, int $lineNumber, string $name, string $message = "") {
 		if (!$this->shouldEmit($fileName, $name, $lineNumber)) {
 			return;
 		}

--- a/src/Output/OutputInterface.php
+++ b/src/Output/OutputInterface.php
@@ -20,9 +20,13 @@ interface OutputInterface {
 	 * @param string $type      The type
 	 * @param string $message   The message
 	 *
-	 * @return mixed
+	 * @return false|array
 	 */
-	function emitError($className, $file, $line, $type, $message = "");
+	function emitError(string $className, string $file, int $line, string $type, string $message = "");
+
+	function shouldEmit(string $file, string $type, int $line):bool;
+
+	function getEmitConfig(string $file, string $type, int $line);
 
 	/**
 	 * output

--- a/src/Output/SocketOutput.php
+++ b/src/Output/SocketOutput.php
@@ -26,7 +26,7 @@ class SocketOutput extends XUnitOutput {
 	 * @param string $message   A human readable message about the error
 	 * @return void
 	 */
-	function emitError($className, $file, $line, $type, $message = "") {
+	function emitError(string $className, string $file, int $line, string $type, string $message = "") {
 		if ($this->shouldEmit($file, $type, $line)) {
 			$arr = [
 				"file" => $file,
@@ -45,7 +45,6 @@ class SocketOutput extends XUnitOutput {
 	 * @return void
 	 */
 	function output($verbose, $extraVerbose) {
-		// TODO: Implement output() method.
 		socket_write($this->socket, "OUTPUT " . base64_encode( serialize(["v" => $verbose,"ev" => $extraVerbose]) . "\n"));
 	}
 

--- a/src/Output/XUnitOutput.php
+++ b/src/Output/XUnitOutput.php
@@ -124,15 +124,14 @@ class XUnitOutput implements OutputInterface {
 	}
 
 	/**
-	 * shouldEmit
 	 *
 	 * @param string $fileName   The file name
 	 * @param string $name       The name
 	 * @param int    $lineNumber The line number the error occurred on.
 	 *
-	 * @return bool
+	 * @return false|array
 	 */
-	public function shouldEmit($fileName, $name, $lineNumber) {
+	public function getEmitConfig(string $fileName, string $name, int $lineNumber) {
 		if (isset($this->silenced[$name]) && $this->silenced[$name] > 0) {
 			return false;
 		}
@@ -159,12 +158,23 @@ class XUnitOutput implements OutputInterface {
 				) {
 					continue;
 				}
-				return true;
+				return $entry['options'] ?? [];
 			} else if (is_string($entry) && self::emitPatternMatches($name, $entry)) {
-				return true;
+				return [];
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * @param string $fileName   The file name
+	 * @param string $name       The name
+	 * @param int    $lineNumber The line number the error occurred on.
+	 *
+	 * @return bool
+	 */
+	public function shouldEmit(string $fileName, string $name, int $lineNumber):bool {
+		return is_array($this->getEmitConfig($fileName,$name,$lineNumber));
 	}
 
 	/**
@@ -204,7 +214,7 @@ class XUnitOutput implements OutputInterface {
 	 *
 	 * @return void
 	 */
-	public function emitError($className, $fileName, $lineNumber, $name, $message="") {
+	public function emitError(string $className, string $fileName, int $lineNumber, string $name, string $message="") {
 
 		if (!$this->shouldEmit($fileName, $name, $lineNumber)) {
 			return;

--- a/src/Phases/AnalyzingPhase.php
+++ b/src/Phases/AnalyzingPhase.php
@@ -89,7 +89,7 @@ class AnalyzingPhase {
 		$traverser3->addVisitor($this->analyzer);
 
 		$this->traversers = [$traverser1, $traverser2, $traverser3];
-		$this->parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
+		$this->parser = (new ParserFactory)->create(ParserFactory::ONLY_PHP7);
 	}
 
 	/**
@@ -336,7 +336,7 @@ class AnalyzingPhase {
 		}
 	}
 
-	protected function retryOnFalse($callable, $retries) {
+	protected function retryOnFalse(callable $callable, int $retries) {
 		$succeeded = false;
 		$tries = 0;
 		while ($succeeded === false && $tries < $retries) {

--- a/src/Phases/IndexingPhase.php
+++ b/src/Phases/IndexingPhase.php
@@ -51,7 +51,7 @@ class IndexingPhase {
 		//if (PhpAstParser::isSupported()) {
 		//	$this->parser = new PhpAstParser();
 		//} else {
-			$this->parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
+			$this->parser = (new ParserFactory)->create(ParserFactory::ONLY_PHP7);
 		//}
 	}
 

--- a/src/SymbolTable/InMemorySymbolTable.php
+++ b/src/SymbolTable/InMemorySymbolTable.php
@@ -53,7 +53,7 @@ class InMemorySymbolTable extends SymbolTable {
 	 *
 	 * @return void
 	 */
-	public function addFunction($name, Function_ $function, $file) {
+	public function addFunction(string $name, Function_ $function, string $file) {
 		$this->functions[strtolower($name)] = $this->basePath . '/' . $file;
 	}
 

--- a/src/SymbolTable/JsonSymbolTable.php
+++ b/src/SymbolTable/JsonSymbolTable.php
@@ -90,7 +90,14 @@ class JsonSymbolTable extends SymbolTable implements PersistantSymbolTable {
 		if (!isset($this->index[$type])) {
 			$this->index[$type] = [];
 		}
-		$this->index[$type][strtolower($name)] = ['file' => $file, 'has_trait' => $hasTrait, 'data' => $data];
+		$this->index[$type][strtolower($name)] = ['name'=>$name, 'file' => $file, 'has_trait' => $hasTrait, 'data' => $data];
+	}
+
+	public function getOriginalName(string $name, $type):string {
+		if (isset($this->index[$type]) && isset($this->index[$type][$name])) {
+			return $this->index[$type][$name]=$name;
+		}
+		return "";
 	}
 
 	/**
@@ -437,7 +444,7 @@ class JsonSymbolTable extends SymbolTable implements PersistantSymbolTable {
 	 *
 	 * @return void
 	 */
-	public function addFunction($name, Function_ $function, $file) {
+	public function addFunction(string $name, Function_ $function, string $file) {
 		$clone = clone $function;
 		$clone->setAttribute("variadic_implementation", VariadicCheckVisitor::isVariadic($function->stmts));
 		$clone->stmts = [];

--- a/src/SymbolTable/SqliteSymbolTable.php
+++ b/src/SymbolTable/SqliteSymbolTable.php
@@ -450,7 +450,7 @@ class SqliteSymbolTable extends SymbolTable implements PersistantSymbolTable {
 	 *
 	 * @return void
 	 */
-	public function addFunction($name, Function_ $function, $file) {
+	public function addFunction(string $name, Function_ $function, string $file) {
 		$clone = clone $function;
 		$clone->setAttribute("variadic_implementation", VariadicCheckVisitor::isVariadic( $function->stmts ));
 		$clone->stmts = [];

--- a/src/SymbolTable/SymbolTable.php
+++ b/src/SymbolTable/SymbolTable.php
@@ -136,6 +136,8 @@ abstract class SymbolTable {
 
 	}
 
+	abstract public function addFunction(string $name, Function_ $function, string $file);
+
 	/**
 	 * getAbstractedClass
 	 *

--- a/tests/TestConfig.php
+++ b/tests/TestConfig.php
@@ -54,7 +54,7 @@ class TestConfig extends Config {
 	 *
 	 * @return string
 	 */
-	public function getBasePath() {
+	public function getBasePath():string {
 		return $this->basePath;
 	}
 
@@ -63,7 +63,7 @@ class TestConfig extends Config {
 	 *
 	 * @return SymbolTable
 	 */
-	public function getSymbolTable() {
+	public function getSymbolTable():SymbolTable {
 		return $this->symbolTable;
 	}
 
@@ -72,7 +72,7 @@ class TestConfig extends Config {
 	 *
 	 * @return mixed|\string[]
 	 */
-	public function getEmitList() {
+	public function getEmitList():array {
 		return $this->emitList;
 	}
 

--- a/tests/TestSuiteSetup.php
+++ b/tests/TestSuiteSetup.php
@@ -73,7 +73,7 @@ abstract class TestSuiteSetup extends TestCase {
 	 *
 	 * @return void
 	 */
-	public function tearDown() {
+	public function tearDown():void {
 		parent::tearDown();
 		unset($this->testFile);
 

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
 >
     <testsuites>
         <testsuite name="Units">

--- a/tests/units/Checks/TestArrowFunctions.php
+++ b/tests/units/Checks/TestArrowFunctions.php
@@ -4,6 +4,6 @@ namespace BambooHR\Guardrail\Tests\units\Checks;
 
 use BambooHR\Guardrail\Tests\TestSuiteSetup;
 
-class TestArrowFunction extends TestSuiteSetup {
+class TestArrowFunctions extends TestSuiteSetup {
 
 }

--- a/tests/units/Checks/TestClassStoredAsVariableCheck.php
+++ b/tests/units/Checks/TestClassStoredAsVariableCheck.php
@@ -17,7 +17,7 @@ class TestClassStoredAsVariableCheck extends TestSuiteSetup {
 	 * @rapid-unit Checks:ClassReferencedAsString:Class referenced as string validation
 	 */
 	public function testClassVariableClass() {
-	//	$this->assertEquals(2, $this->runAnalyzerOnFile('.1.inc', ErrorConstants::TYPE_CLASS_STORED_VARIABLE));
+		$this->assertEquals(2, $this->runAnalyzerOnFile('.1.inc', ErrorConstants::TYPE_CLASS_STORED_VARIABLE));
 	}
 
 	/**
@@ -27,7 +27,7 @@ class TestClassStoredAsVariableCheck extends TestSuiteSetup {
 	 * @rapid-unit Checks:ClassReferencedAsString:Class referenced as string validation
 	 */
 	public function testClassVariableAbstractClass() {
-	//	$this->assertEquals(1, $this->runAnalyzerOnFile('.2.inc', ErrorConstants::TYPE_CLASS_STORED_VARIABLE));
+		$this->assertEquals(1, $this->runAnalyzerOnFile('.2.inc', ErrorConstants::TYPE_CLASS_STORED_VARIABLE));
 	}
 
 	/**
@@ -37,7 +37,7 @@ class TestClassStoredAsVariableCheck extends TestSuiteSetup {
 	 * @rapid-unit Checks:ClassReferencedAsString:Class referenced as string validation
 	 */
 	public function testClassVariableNamespacedClass() {
-	//	$this->assertEquals(1, $this->runAnalyzerOnFile('.3.inc', ErrorConstants::TYPE_CLASS_STORED_VARIABLE));
+		$this->assertEquals(1, $this->runAnalyzerOnFile('.3.inc', ErrorConstants::TYPE_CLASS_STORED_VARIABLE));
 	}
 
 	/**
@@ -47,7 +47,7 @@ class TestClassStoredAsVariableCheck extends TestSuiteSetup {
 	 * @rapid-unit Checks:ClassReferencedAsString:Class referenced as string validation
 	 */
 	public function testClassVariableNamespacedAbstractClass() {
-	//	$this->assertEquals(1, $this->runAnalyzerOnFile('.4.inc', ErrorConstants::TYPE_CLASS_STORED_VARIABLE));
+		$this->assertEquals(1, $this->runAnalyzerOnFile('.4.inc', ErrorConstants::TYPE_CLASS_STORED_VARIABLE));
 	}
 
 	/**
@@ -57,7 +57,7 @@ class TestClassStoredAsVariableCheck extends TestSuiteSetup {
 	 * @rapid-unit Checks:ClassReferencedAsString:Class referenced as string validation
 	 */
 	public function testClassVariableClassNotInString() {
-	//	$this->assertEquals(0, $this->runAnalyzerOnFile('.5.inc', ErrorConstants::TYPE_CLASS_STORED_VARIABLE));
+		$this->assertEquals(0, $this->runAnalyzerOnFile('.5.inc', ErrorConstants::TYPE_CLASS_STORED_VARIABLE));
 	}
 
 	/**
@@ -67,7 +67,7 @@ class TestClassStoredAsVariableCheck extends TestSuiteSetup {
 	 * @rapid-unit Checks:ClassReferencedAsString:Class referenced as string validation
 	 */
 	public function testClassVariableNamespacedClassNotInString() {
-	//	$this->assertEquals(0, $this->runAnalyzerOnFile('.6.inc', ErrorConstants::TYPE_CLASS_STORED_VARIABLE));
+		$this->assertEquals(0, $this->runAnalyzerOnFile('.6.inc', ErrorConstants::TYPE_CLASS_STORED_VARIABLE));
 	}
 
 	/**
@@ -76,8 +76,8 @@ class TestClassStoredAsVariableCheck extends TestSuiteSetup {
 	 * @return void
 	 * @rapid-unit Checks:ClassReferencedAsString:Class referenced as string validation
 	 */
-	public function testNamspacedClassVariableClass() {
-	//	$this->assertEquals(1, $this->runAnalyzerOnFile('.7.inc', ErrorConstants::TYPE_CLASS_STORED_VARIABLE));
+	public function testNamespacedClassVariableClass() {
+		$this->assertEquals(1, $this->runAnalyzerOnFile('.7.inc', ErrorConstants::TYPE_CLASS_STORED_VARIABLE));
 	}
 
 }

--- a/tests/units/Checks/TestClassStoredAsVariableCheck.php
+++ b/tests/units/Checks/TestClassStoredAsVariableCheck.php
@@ -17,7 +17,7 @@ class TestClassStoredAsVariableCheck extends TestSuiteSetup {
 	 * @rapid-unit Checks:ClassReferencedAsString:Class referenced as string validation
 	 */
 	public function testClassVariableClass() {
-		$this->assertEquals(2, $this->runAnalyzerOnFile('.1.inc', ErrorConstants::TYPE_CLASS_STORED_VARIABLE));
+		//$this->assertEquals(2, $this->runAnalyzerOnFile('.1.inc', ErrorConstants::TYPE_CLASS_STORED_VARIABLE));
 	}
 
 	/**
@@ -27,7 +27,7 @@ class TestClassStoredAsVariableCheck extends TestSuiteSetup {
 	 * @rapid-unit Checks:ClassReferencedAsString:Class referenced as string validation
 	 */
 	public function testClassVariableAbstractClass() {
-		$this->assertEquals(1, $this->runAnalyzerOnFile('.2.inc', ErrorConstants::TYPE_CLASS_STORED_VARIABLE));
+		//$this->assertEquals(1, $this->runAnalyzerOnFile('.2.inc', ErrorConstants::TYPE_CLASS_STORED_VARIABLE));
 	}
 
 	/**
@@ -37,7 +37,7 @@ class TestClassStoredAsVariableCheck extends TestSuiteSetup {
 	 * @rapid-unit Checks:ClassReferencedAsString:Class referenced as string validation
 	 */
 	public function testClassVariableNamespacedClass() {
-		$this->assertEquals(1, $this->runAnalyzerOnFile('.3.inc', ErrorConstants::TYPE_CLASS_STORED_VARIABLE));
+		//$this->assertEquals(1, $this->runAnalyzerOnFile('.3.inc', ErrorConstants::TYPE_CLASS_STORED_VARIABLE));
 	}
 
 	/**
@@ -47,7 +47,7 @@ class TestClassStoredAsVariableCheck extends TestSuiteSetup {
 	 * @rapid-unit Checks:ClassReferencedAsString:Class referenced as string validation
 	 */
 	public function testClassVariableNamespacedAbstractClass() {
-		$this->assertEquals(1, $this->runAnalyzerOnFile('.4.inc', ErrorConstants::TYPE_CLASS_STORED_VARIABLE));
+		//$this->assertEquals(1, $this->runAnalyzerOnFile('.4.inc', ErrorConstants::TYPE_CLASS_STORED_VARIABLE));
 	}
 
 	/**
@@ -57,7 +57,7 @@ class TestClassStoredAsVariableCheck extends TestSuiteSetup {
 	 * @rapid-unit Checks:ClassReferencedAsString:Class referenced as string validation
 	 */
 	public function testClassVariableClassNotInString() {
-		$this->assertEquals(0, $this->runAnalyzerOnFile('.5.inc', ErrorConstants::TYPE_CLASS_STORED_VARIABLE));
+		//$this->assertEquals(0, $this->runAnalyzerOnFile('.5.inc', ErrorConstants::TYPE_CLASS_STORED_VARIABLE));
 	}
 
 	/**
@@ -67,7 +67,7 @@ class TestClassStoredAsVariableCheck extends TestSuiteSetup {
 	 * @rapid-unit Checks:ClassReferencedAsString:Class referenced as string validation
 	 */
 	public function testClassVariableNamespacedClassNotInString() {
-		$this->assertEquals(0, $this->runAnalyzerOnFile('.6.inc', ErrorConstants::TYPE_CLASS_STORED_VARIABLE));
+		//$this->assertEquals(0, $this->runAnalyzerOnFile('.6.inc', ErrorConstants::TYPE_CLASS_STORED_VARIABLE));
 	}
 
 	/**
@@ -77,7 +77,7 @@ class TestClassStoredAsVariableCheck extends TestSuiteSetup {
 	 * @rapid-unit Checks:ClassReferencedAsString:Class referenced as string validation
 	 */
 	public function testNamespacedClassVariableClass() {
-		$this->assertEquals(1, $this->runAnalyzerOnFile('.7.inc', ErrorConstants::TYPE_CLASS_STORED_VARIABLE));
+		//$this->assertEquals(1, $this->runAnalyzerOnFile('.7.inc', ErrorConstants::TYPE_CLASS_STORED_VARIABLE));
 	}
 
 }

--- a/tests/units/Checks/TestData/TestClassStoredAsVariableCheck.5.inc
+++ b/tests/units/Checks/TestData/TestClassStoredAsVariableCheck.5.inc
@@ -1,6 +1,6 @@
 <?php
 
-abstract class MyTestClass {
+class MyTestClass {
 	public function checkStoredClass() {
 
 	}

--- a/tests/units/Checks/TestData/TestClassStoredAsVariableCheck.7.inc
+++ b/tests/units/Checks/TestData/TestClassStoredAsVariableCheck.7.inc
@@ -9,9 +9,9 @@ abstract class MyTestClass {
 class MyOtherClass {
 
 	public function checkStoredClass() {
-		$classVar = 'BambooHR\Guardrail\Checks\MyTestClass';
+		$classVar = 'BambooHR\\Guardrail\\Checks\\MyTestClass';
 		$object = new $classVar;
 
-		$otherNonClass = 'BambooHR\Guardrail\Checks\WasHere';
+		$otherNonClass = 'BambooHR\\Guardrail\\Checks\\WasHere';
 	}
 }

--- a/tests/units/Checks/TestData/TestFunctionCallCheck.9.inc
+++ b/tests/units/Checks/TestData/TestFunctionCallCheck.9.inc
@@ -4,15 +4,17 @@ class A {}
 
 class B {}
 
-function C(A | B $param): A | B {
+
+// Not part of the union
+class C {}
+
+// D only accepts A or B, not D.
+function D(A | B $param): A | B {
 
 }
 
-class D {}
 
-$a = new A();
-C($a);
-$b = new B();
-C($b);
-$d = new D();
-C($d);
+
+D(new A());
+D(new B());
+D(new C());

--- a/tests/units/UtilTest.php
+++ b/tests/units/UtilTest.php
@@ -71,11 +71,11 @@ class UtilTest  extends TestCase {
 	 *
 	 * @return void
 	 * @dataProvider exceptionData
-	 * @expectedException \InvalidArgumentException
 	 * @rapid-unit Util:ConfigDirectoryValidation:Validation will throw exception for missing data.
 	 */
-	public function testConfigDirectoriesAreValidThrowsException($baseDirectory, $paths) {
-		$this->assertFalse(Util::configDirectoriesAreValid($baseDirectory, $paths));
+	public function testConfigDirectoriesAreValidThrowsException($baseDirectory, $paths, $class) {
+		$this->expectException( $class );
+		Util::configDirectoriesAreValid($baseDirectory, $paths);
 	}
 
 	/**
@@ -85,9 +85,9 @@ class UtilTest  extends TestCase {
 	 */
 	public function exceptionData() {
 		return [
-			[null, ''],
-			[new \stdClass(), null],
-			[0, []],
+			[null, '', \TypeError::class],
+			[new \stdClass(), null, \TypeError::class],
+			[0, [], \InvalidArgumentException::class],
 		];
 	}
 
@@ -137,6 +137,20 @@ class UtilTest  extends TestCase {
 	}
 
 	/**
+	 * testJsonFileContentIsValidThrowsException
+	 *
+	 * @param string $file     The file to test
+	 *
+	 * @return void
+	 * @dataProvider missingJsonFiles
+	 * @rapid-unit Util:JsonFileValidation:Missing files will throw exceptions
+	 */
+	public function testJsonFileContentIsValidThrowsException($file) {
+		$this->expectException(\InvalidArgumentException::class);
+		Util::jsonFileContentIsValid($file);
+	}
+
+	/**
 	 * jsonFileData
 	 *
 	 * @return array
@@ -146,20 +160,6 @@ class UtilTest  extends TestCase {
 			[__DIR__ . '/sampleData/good.json', true],
 			[__DIR__ . '/sampleData/bad.json', false],
 		];
-	}
-
-	/**
-	 * testJsonFileContentIsValidThrowsException
-	 *
-	 * @param string $file     The file to test
-	 *
-	 * @return void
-	 * @expectedException \InvalidArgumentException
-	 * @dataProvider missingJsonFiles
-	 * @rapid-unit Util:JsonFileValidation:Missing files will throw exceptions
-	 */
-	public function testJsonFileContentIsValidThrowsException($file) {
-		Util::jsonFileContentIsValid($file);
 	}
 
 	/**


### PR DESCRIPTION
- Upgrades code to PHP 7.x constructs
- Upgrades to newer PhpParser and Phpunit
- Strengthens typing in key classes
- Adds support for recognizing Throwable as a base of Exception|Error
- Faster UseStatementCaseCheck