### PR TITLE
Named parameter support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,6 @@
     "ext-pcntl": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "<6.0"
+    "phpunit/phpunit": "^9.0"
   }
 }

--- a/src/Abstractions/ClassAbstraction.php
+++ b/src/Abstractions/ClassAbstraction.php
@@ -6,6 +6,7 @@
  */
 
 use BambooHR\Guardrail\Config;
+use PhpParser\Node\NullableType;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassConst;
 use PhpParser\Node\Stmt\ClassLike;
@@ -185,7 +186,8 @@ class ClassAbstraction implements ClassInterface {
 					} else {
 						$access = "public";
 					}
-					$type = strval($prop->type);
+					$type = ($prop->type instanceof NullableType) ? strval($prop->type->type) : strval($prop->type);
+
 					if (Config::shouldUseDocBlockForProperties() && empty($type)) {
 						$type = $propertyProperty->getAttribute("namespacedType");
 					}

--- a/src/Abstractions/ClassMethod.php
+++ b/src/Abstractions/ClassMethod.php
@@ -96,7 +96,7 @@ class ClassMethod implements MethodInterface {
 			$ret[] = new FunctionLikeParameter(
 				$param->type instanceof NullableType ? $param->type->type : $param->type,
 				$param->var->name,
-				$param->default != null,
+				$param->default != null || $param->variadic,
 				$param->byRef,
 				$param->type instanceof NullableType || ($param->default instanceof ConstFetch && strcasecmp($param->default->name, "null") == 0)
 			);

--- a/src/Abstractions/ReflectedFunction.php
+++ b/src/Abstractions/ReflectedFunction.php
@@ -62,7 +62,8 @@ class ReflectedFunction implements FunctionLikeInterface {
 	public function getReturnType() {
 		if ( method_exists($this->refl, "getReturnType")) {
 			$type = $this->refl->getReturnType();
-			if ($type) {
+			// Other possibility is ReflectionUnionType, which we don't currently handle.
+			if ($type instanceof \ReflectionNamedType) {
 				return $type->getName();
 			}
 		}

--- a/src/Checks/CallCheck.php
+++ b/src/Checks/CallCheck.php
@@ -1,5 +1,6 @@
 <?php namespace BambooHR\Guardrail\Checks;
 
+use BambooHR\Guardrail\Abstractions\FunctionLikeParameter;
 use BambooHR\Guardrail\Checks\BaseCheck;
 use BambooHR\Guardrail\Checks\ErrorConstants;
 use BambooHR\Guardrail\Scope;
@@ -21,65 +22,121 @@ abstract class CallCheck extends BaseCheck {
 	protected $inferenceEngine;
 
 	/**
-	 * @param string                  $fileName -
-	 * @param Node                    $node     -
-	 * @param string                  $name     -
-	 * @param Scope                   $scope    -
-	 * @param ClassLike               $inside   -
-	 * @param Node\Arg                $arg      -
-	 * @param int                     $index    -
-	 * @param FunctionLikeParameter[] $params   -
+	 * @param string                  $fileName
+	 * @param Node                    $node
+	 * @param string                  $name
+	 * @param Scope                   $scope
+	 * @param ClassLike|null          $inside
+	 * @param Node\Arg[]              $args
+	 * @param FunctionLikeParameter[] $params
 	 * @return void
 	 */
-	protected function checkParam($fileName, $node, $name, Scope $scope, ClassLike $inside = null, $arg, $index, $params) {
-		if ($scope && $arg->value instanceof Node\Expr && $index < count($params)) {
-			$variableName = $params[$index]->getName();
-			list($type, $attributes) = $this->inferenceEngine->inferType($inside, $arg->value, $scope);
-			if ($arg->unpack) {
-				// Check if they called with ...$array.  If so, make sure $array is of type undefined or array
-				$isSplatable = (
-					substr($type, -2) == "[]" ||
-					$type == "array" ||
-					$type == Scope::ARRAY_TYPE ||
-					$type == Scope::UNDEFINED ||
-					$type == Scope::MIXED_TYPE ||
-					$type == "" ||
-					$this->symbolTable->isParentClassOrInterface(\Traversable::class, $type)
-				);
-				if (!$isSplatable) {
-					$this->emitError($fileName, $node, ErrorConstants::TYPE_SIGNATURE_TYPE, "Splat (...) operator requires an array or traversable object.  Passing " . Scope::nameFromConst($type) . " from \$$variableName.");
+	protected function checkParams($fileName, $node, $name, Scope $scope, ClassLike $inside = null, array $args, array $params) {
+		$covered = [];
+		$named = false;
+		foreach($args as $index=>$arg) {
+			if ($arg->name==null) {
+				if(!$named) {
+					$covered[$index] = 1;
+					if($index<count($params)) {
+						$this->checkParam($fileName, $node, $name, $scope, $inside, $arg, $params[$index]);
+					}
+				} else {
+					$this->emitError($fileName, $arg, ErrorConstants::TYPE_SIGNATURE_TYPE,"Attempt to pass positional param after named param");
+					break;
 				}
-				return;// After we unpack an arg, we can't check the remaining parameters.
 			} else {
-				if ($params[$index]->getType() != "") {
-					// Reference mismatch
-					if ($params[$index]->isReference() &&
-						!(
-							$arg->value instanceof Variable ||
-							$arg->value instanceof Expr\ArrayDimFetch ||
-							$arg->value instanceof Expr\PropertyFetch
-						)
-					) {
-						$this->emitError($fileName, $node, ErrorConstants::TYPE_SIGNATURE_TYPE, "Value passed to $name() parameter \$$variableName must be a reference type not an expression.");
-					}
-
-					// Type mismatch
-					$expectedType = $params[$index]->getType();
-					if ($expectedType instanceof UnionType) {
-						$expectedTypes = $expectedType->types;
+				$named = true;
+				$index2=self::findParam($params,$arg->name->name);
+				if($index2>=0) {
+					if ($covered[$index2]) {
+						$this->emitError($fileName, $params[$index2], ErrorConstants::TYPE_SIGNATURE_TYPE, "Attempt to pass param \"" . $arg->name->name . "\" twice");
 					} else {
-						$expectedTypes = [$expectedType];
+						$covered[$index2]=1;
+						$this->checkParam($fileName, $node, $name, $scope, $inside, $arg, $params[$index2]);
+						break;
 					}
-					$this->verifyParamType($fileName, $node, $name, $variableName, $arg, $inside, $scope, $type, $expectedTypes);
+				}
+			}
+		}
+		foreach($params as $index=>$param) {
+			if(!$covered[$index] && !$param->isOptional()) {
+				$this->emitError($fileName, $node,ErrorConstants::TYPE_SIGNATURE_TYPE, "Required parameter ".$param->getName()." was not passed");
+			}
+		}
+	}
 
-					// Nulls mismatch
-					if (!$params[$index]->isNullable()) {
-						if ($type == Scope::NULL_TYPE) {
-							$this->emitError($fileName, $node, ErrorConstants::TYPE_SIGNATURE_TYPE, "NULL passed to $name parameter \$$variableName that does not accept nulls");
-						} /*else if ($maybeNull == Scope::NULL_POSSIBLE) {
-							$this->emitError($fileName, $node, ErrorConstants::TYPE_SIGNATURE_TYPE, "Potentially NULL value passed to $name parameter \$$variableName that does not accept nulls");
-						}*/
-					}
+	/**
+	 * @param array  $params
+	 * @param string $name
+	 * @return int
+	 */
+	static function findParam(array $params, string $name):int {
+		foreach($params as $index2=>$param) {
+			if (strcasecmp($param->getName(), $name)==0) {
+				return $index2;
+			}
+		}
+		return -1;
+	}
+
+	/**
+	 * @param string                $fileName -
+	 * @param Node                  $node     -
+	 * @param string                $name     -
+	 * @param Scope                 $scope    -
+	 * @param ClassLike             $inside   -
+	 * @param Node\Arg              $arg      -
+	 * @param FunctionLikeParameter $param    -
+	 * @return void
+	 */
+	protected function checkParam($fileName, $node, $name, Scope $scope, ClassLike $inside = null, Node\Arg $arg, FunctionLikeParameter $param) {
+		$variableName = $param->getName();
+		list($type, $attributes) = $this->inferenceEngine->inferType($inside, $arg->value, $scope);
+		if ($arg->unpack) {
+			// Check if they called with ...$array.  If so, make sure $array is of type undefined or array
+			$isSplatable = (
+				substr($type, -2) == "[]" ||
+				$type == "array" ||
+				$type == Scope::ARRAY_TYPE ||
+				$type == Scope::UNDEFINED ||
+				$type == Scope::MIXED_TYPE ||
+				$type == "" ||
+				$this->symbolTable->isParentClassOrInterface(\Traversable::class, $type)
+			);
+			if (!$isSplatable) {
+				$this->emitError($fileName, $node, ErrorConstants::TYPE_SIGNATURE_TYPE, "Splat (...) operator requires an array or traversable object.  Passing " . Scope::nameFromConst($type) . " from \$$variableName.");
+			}
+			return;// After we unpack an arg, we can't check the remaining parameters.
+		} else {
+			if ($params->getType() != "") {
+				// Reference mismatch
+				if ($params->isReference() &&
+					!(
+						$arg->value instanceof Variable ||
+						$arg->value instanceof Expr\ArrayDimFetch ||
+						$arg->value instanceof Expr\PropertyFetch
+					)
+				) {
+					$this->emitError($fileName, $node, ErrorConstants::TYPE_SIGNATURE_TYPE, "Value passed to $name() parameter \$$variableName must be a reference type not an expression.");
+				}
+
+				// Type mismatch
+				$expectedType = $params->getType();
+				if ($expectedType instanceof UnionType) {
+					$expectedTypes = $expectedType->types;
+				} else {
+					$expectedTypes = [$expectedType];
+				}
+				$this->verifyParamType($fileName, $node, $name, $variableName, $arg, $inside, $scope, $type, $expectedTypes);
+
+				// Nulls mismatch
+				if (!$params->isNullable()) {
+					if ($type == Scope::NULL_TYPE) {
+						$this->emitError($fileName, $node, ErrorConstants::TYPE_SIGNATURE_TYPE, "NULL passed to $name parameter \$$variableName that does not accept nulls");
+					} /*else if ($maybeNull == Scope::NULL_POSSIBLE) {
+						$this->emitError($fileName, $node, ErrorConstants::TYPE_SIGNATURE_TYPE, "Potentially NULL value passed to $name parameter \$$variableName that does not accept nulls");
+					}*/
 				}
 			}
 		}
@@ -92,6 +149,9 @@ abstract class CallCheck extends BaseCheck {
 			return;
 		}
 		foreach ($expectedTypes as $expectedType) {
+			if (strcasecmp($expectedType, 'countable') == 0 && ($type == Scope::ARRAY_TYPE || substr($type, -2) == "[]")) {
+				return;
+			}
 			if ($this->symbolTable->isParentClassOrInterface($expectedType, $type)) {
 				return;
 			}

--- a/src/Checks/FunctionCallCheck.php
+++ b/src/Checks/FunctionCallCheck.php
@@ -110,9 +110,7 @@ class FunctionCallCheck extends CallCheck {
 					}
 
 					$params = $func->getParameters();
-					foreach ($node->args as $index => $arg) {
-						$this->checkParam($fileName, $node, $name, $scope, $inside, $arg, $index, $params);
-					}
+					$this->checkParams($fileName, $node, $name, $scope, $inside, $node->args, $params);
 				} else {
 					$this->emitError($fileName, $node, ErrorConstants::TYPE_UNKNOWN_FUNCTION, "Call to unknown function $name");
 				}

--- a/src/Checks/MethodCall.php
+++ b/src/Checks/MethodCall.php
@@ -152,8 +152,6 @@ class MethodCall extends CallCheck {
 		}
 
 		$name = $className . "->" . $methodName;
-		foreach ($node->args as $index => $arg) {
-			$this->checkParam($fileName, $node, $name, $scope, $inside, $arg, $index, $params);
-		}
+		$this->checkParams($fileName, $node, $name, $scope, $inside, $node->args, $params);
 	}
 }

--- a/src/Checks/MethodCall.php
+++ b/src/Checks/MethodCall.php
@@ -129,7 +129,6 @@ class MethodCall extends CallCheck {
 	protected function checkMethod($fileName, $node, $className, $methodName, Scope $scope, MethodInterface $method, ClassLike $inside=null) {
 		if ($method->isStatic()) {
 			$this->emitError($fileName, $node, ErrorConstants::TYPE_INCORRECT_DYNAMIC_CALL, "Call to static method of $className::" . $method->getName() . " non-statically");
-			return;
 		}
 
 		if ($method->getAccessLevel() == "private" && (!$inside || !isset($inside->namespacedName) || strcasecmp($className, $inside->namespacedName) != 0)) {

--- a/src/CommandLineRunner.php
+++ b/src/CommandLineRunner.php
@@ -73,10 +73,7 @@ where: -p #/#                 = Define the number of partitions and the current 
 			exit(1);
 		}
 
-		if (!extension_loaded("pdo_sqlite") || !extension_loaded("sqlite3")) {
-			echo "Guardrail requires the PDO Sqlite extension, which is not loaded.\n";
-			exit(1);
-		}
+
 
 		try {
 			$config = new Config($argv);

--- a/src/Config.php
+++ b/src/Config.php
@@ -310,6 +310,10 @@ class Config {
 					break;
 				case '-s':
 					$this->preferredTable = self::SQLITE_SYMBOL_TABLE;
+					if (!extension_loaded("pdo_sqlite") || !extension_loaded("sqlite3")) {
+						echo "Guardrail requires the PDO Sqlite extension, which is not loaded.\n";
+						throw new InvalidConfigException();
+					}
 					break;
 				case '-m':
 					$this->preferredTable = self::MEMORY_SYMBOL_TABLE;

--- a/src/DirectoryLister.php
+++ b/src/DirectoryLister.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace BambooHR\Guardrail;
+
+class DirectoryLister {
+	static function getGenerator(string ...$dirs) {
+		while (NULL !== ($dir = array_shift($dirs))) {
+			if ($dh = opendir($dir)) {
+				while (false !== ($file = readdir($dh))) {
+					if ($file != '.' && $file != '..') {
+						$path = $dir . DIRECTORY_SEPARATOR . $file;
+						if (is_dir($path)) {
+							$dirs[] = $path;
+						} else {
+							yield $path;
+						}
+					}
+				}
+				closedir($dh);
+			}
+		}
+	}
+}

--- a/src/ExtraStubs/Exception.php
+++ b/src/ExtraStubs/Exception.php
@@ -1,14 +1,13 @@
 <?php
 
-class Exception {
+class Exception implements Throwable {
 	function __construct($message="", $code=0, $previous=null) { }
-	function getMessage() { }
+	function getMessage():string { return ""; }
 	function getPrevious() { }
 	function getCode() { }
-	function getFile() { }
-	function getLine() { }
-	function getTrace() { }
-	function getTraceAsString() { }
-	function __toString() {
- return ""; }
+	function getFile():string { return ""; }
+	function getLine():int { return 0;}
+	function getTrace():array { return []; }
+	function getTraceAsString():string { return ""; }
+	function __toString() { return ""; }
 }

--- a/src/NodeVisitors/DocBlockNameResolver.php
+++ b/src/NodeVisitors/DocBlockNameResolver.php
@@ -63,6 +63,7 @@ class DocBlockNameResolver extends NodeVisitorAbstract {
 		}
 	}
 
+
 	/**
 	 * importVarType
 	 *
@@ -95,7 +96,7 @@ class DocBlockNameResolver extends NodeVisitorAbstract {
 		if ($comment) {
 			$str = $comment->getText();
 			try {
-				$this->processDockBlockReturn($node, $str);
+				$this->processDocBlockReturn($node, $str);
 			} catch (\InvalidArgumentException $exception) {
 				// Skip it.
 			}
@@ -152,7 +153,7 @@ class DocBlockNameResolver extends NodeVisitorAbstract {
 	 *
 	 * @return void
 	 */
-	private function processDockBlockReturn($node, $str) {
+	private function processDocBlockReturn($node, $str) {
 		if ($str && preg_match_all('/@return +([A-Z0-9_|\\\\]+(?:\[\])*)/i', $str, $matchArray, PREG_SET_ORDER)) {
 			$returnType = strval($matchArray[0][1]);
 			list($returnType) = explode(" ", $returnType, 2);

--- a/src/Scope.php
+++ b/src/Scope.php
@@ -63,7 +63,7 @@ class Scope {
 	static public function constFromName($str) {
 		if (strcasecmp($str, "null") == 0) {
 			return static::NULL_TYPE;
-		} elseif (strcasecmp($str, "bool") == 0) {
+		} elseif (strcasecmp($str, "bool") == 0 || strcasecmp($str, "false") ==0) {
 			return static::BOOL_TYPE;
 		} elseif (strcasecmp($str, "int") == 0) {
 			return static::INT_TYPE;

--- a/tests/TestSuiteSetup.php
+++ b/tests/TestSuiteSetup.php
@@ -73,7 +73,7 @@ abstract class TestSuiteSetup extends TestCase {
 	 *
 	 * @return void
 	 */
-	public function tearDown() {
+	public function tearDown():void {
 		parent::tearDown();
 		unset($this->testFile);
 

--- a/tests/units/Checks/TestArrowFunctions.php
+++ b/tests/units/Checks/TestArrowFunctions.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace BambooHR\Guardrail\Tests\units\Checks;
-
-use BambooHR\Guardrail\Tests\TestSuiteSetup;
-
-class TestArrowFunction extends TestSuiteSetup {
-
-}

--- a/tests/units/Checks/TestData/TestNamedParameters.1.inc
+++ b/tests/units/Checks/TestData/TestNamedParameters.1.inc
@@ -18,6 +18,7 @@ TestNamedParameters::foo(bar:5, foo:"Testing", baz:"bz");
 bar("Test", bar:10);
 
 
+
 TestNamedParameters::foo(foo:"Testing",1,"bz");
 
 bar(foo:"1", foo:"2", bar: 5);

--- a/tests/units/Checks/TestData/TestNamedParameters.1.inc
+++ b/tests/units/Checks/TestData/TestNamedParameters.1.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace BambooHR\Guardrail\Tests\units\Checks\TestData;
+
+class TestNamedParameters {
+	static function foo(string $foo, int $bar, string $baz="") {
+
+	}
+}
+
+function bar(string $foo, int $bar, string $baz="") {
+
+}
+
+
+TestNamedParameters::foo(bar:5, foo:"Testing", baz:"bz");
+
+bar("Test", bar:10);
+
+
+TestNamedParameters::foo(foo:"Testing",1,"bz");
+
+bar(foo:"1", foo:"2", bar: 5);
+
+
+bar(bat:"2",foo:"1", bar:5);

--- a/tests/units/Checks/TestNamedParameters.php
+++ b/tests/units/Checks/TestNamedParameters.php
@@ -16,6 +16,6 @@ class TestNamedParameters extends TestSuiteSetup {
 	 * @return void
 	 */
 	public function testBadCalls() {
-		$this->assertEquals(3, $this->runAnalyzerOnFile('.1.inc', ErrorConstants::TYPE_SIGNATURE_TYPE));
+		$this->assertEquals(4, $this->runAnalyzerOnFile('.1.inc', ErrorConstants::TYPE_SIGNATURE_TYPE));
 	}
 }

--- a/tests/units/Checks/TestNamedParameters.php
+++ b/tests/units/Checks/TestNamedParameters.php
@@ -1,0 +1,21 @@
+<?php namespace BambooHR\Guardrail\Tests\Checks;
+
+use BambooHR\Guardrail\Checks\ErrorConstants;
+use BambooHR\Guardrail\Tests\TestSuiteSetup;
+
+/**
+ * Class TestNamedParameters
+ *
+ * @package BambooHR\Guardrail\Tests\Checks
+ */
+class TestNamedParameters extends TestSuiteSetup {
+
+	/**
+	 * testBadCalls
+	 *
+	 * @return void
+	 */
+	public function testBadCalls() {
+		$this->assertEquals(3, $this->runAnalyzerOnFile('.1.inc', ErrorConstants::TYPE_SIGNATURE_TYPE));
+	}
+}

--- a/tests/units/UtilTest.php
+++ b/tests/units/UtilTest.php
@@ -71,11 +71,11 @@ class UtilTest  extends TestCase {
 	 *
 	 * @return void
 	 * @dataProvider exceptionData
-	 * @expectedException \InvalidArgumentException
 	 * @rapid-unit Util:ConfigDirectoryValidation:Validation will throw exception for missing data.
 	 */
 	public function testConfigDirectoriesAreValidThrowsException($baseDirectory, $paths) {
-		$this->assertFalse(Util::configDirectoriesAreValid($baseDirectory, $paths));
+		$this->expectException(\InvalidArgumentException::class);
+		Util::configDirectoriesAreValid($baseDirectory, $paths);
 	}
 
 	/**
@@ -154,11 +154,11 @@ class UtilTest  extends TestCase {
 	 * @param string $file     The file to test
 	 *
 	 * @return void
-	 * @expectedException \InvalidArgumentException
 	 * @dataProvider missingJsonFiles
 	 * @rapid-unit Util:JsonFileValidation:Missing files will throw exceptions
 	 */
 	public function testJsonFileContentIsValidThrowsException($file) {
+		$this->expectException(\InvalidArgumentException::class);
 		Util::jsonFileContentIsValid($file);
 	}
 


### PR DESCRIPTION
Adds support for Named Parameter passing in PHP 8.  Includes unit tests for the same.  Also, discovered that parameter to static method calls were not being type checked.  Those parameters will now be checked just like any other function/method call.    