### PR TITLE
Add a fix for the __toString method on an object

### DIFF
--- a/src/Checks/CallCheck.php
+++ b/src/Checks/CallCheck.php
@@ -5,6 +5,7 @@ use BambooHR\Guardrail\Checks\BaseCheck;
 use BambooHR\Guardrail\Checks\ErrorConstants;
 use BambooHR\Guardrail\Scope;
 use BambooHR\Guardrail\TypeInferrer;
+use BambooHR\Guardrail\Util;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
@@ -148,6 +149,10 @@ abstract class CallCheck extends BaseCheck {
 			return;
 		}
 		foreach ($expectedTypes as $expectedType) {
+			//If the expected type is a string and the given argument is an object with a __toString method, the argument is valid.
+			if (strcasecmp($expectedType, 'string') == 0 && Util::findAbstractedMethod($type, '__toString', $this->symbolTable)) {
+				return;
+			}
 			if (strcasecmp($expectedType, 'countable') == 0 && ($type == Scope::ARRAY_TYPE || substr($type, -2) == "[]")) {
 				return;
 			}

--- a/tests/units/Checks/TestData/TestFunctionCallCheck.10.inc
+++ b/tests/units/Checks/TestData/TestFunctionCallCheck.10.inc
@@ -6,6 +6,9 @@ class HasToString {
 	}
 }
 
+class NoHasToString {
+}
+
 class ClassWithStringRequirement {
 	public function methodWithStringRequirement(string $required) {
 	}
@@ -15,9 +18,13 @@ function functionWithStringRequirement(string $required) {
 }
 
 $HasToString = new HasToString();
+$NoHasToString = new NoHasToString();
+$ClassWithStringRequirement = new ClassWithStringRequirement();
 
-(new ClassWithStringRequirement())->methodWithStringRequirement($HasToString);
-(new ClassWithStringRequirement())->methodWithStringRequirement('single quote string');
+$ClassWithStringRequirement->methodWithStringRequirement($HasToString); //Should succeed
+$ClassWithStringRequirement->methodWithStringRequirement('single quote string'); //Should succeed
+$ClassWithStringRequirement->methodWithStringRequirement($NoHasToString); //Should fail
 
-functionWithStringRequirement($HasToString);
-functionWithStringRequirement("double quote string");
+functionWithStringRequirement($HasToString); //Should succeed
+functionWithStringRequirement("double quote string"); //Should succeed
+functionWithStringRequirement($NoHasToString); //Should fail

--- a/tests/units/Checks/TestData/TestFunctionCallCheck.10.inc
+++ b/tests/units/Checks/TestData/TestFunctionCallCheck.10.inc
@@ -1,0 +1,23 @@
+<?php
+
+class HasToString {
+	public function __toString(): string {
+		return '';
+	}
+}
+
+class ClassWithStringRequirement {
+	public function methodWithStringRequirement(string $required) {
+	}
+}
+
+function functionWithStringRequirement(string $required) {
+}
+
+$HasToString = new HasToString();
+
+(new ClassWithStringRequirement())->methodWithStringRequirement($HasToString);
+(new ClassWithStringRequirement())->methodWithStringRequirement('single quote string');
+
+functionWithStringRequirement($HasToString);
+functionWithStringRequirement("double quote string");

--- a/tests/units/Checks/TestFunctionCallCheck.php
+++ b/tests/units/Checks/TestFunctionCallCheck.php
@@ -99,6 +99,6 @@ class TestFunctionCallCheck extends TestSuiteSetup {
 	 * @rapid-unit Checks:FunctionCallCheck:Ensures that passing an object with a __toString method is allowed as a valid argument to a method or function with a string requirement
 	 */
 	public function testObjectWith__toStringMethod() {
-		$this->assertEquals(0, $this->runAnalyzerOnFile('.10.inc', ErrorConstants::TYPE_SIGNATURE_TYPE));
+		$this->assertEquals(2, $this->runAnalyzerOnFile('.10.inc', ErrorConstants::TYPE_SIGNATURE_TYPE));
 	}
 }

--- a/tests/units/Checks/TestFunctionCallCheck.php
+++ b/tests/units/Checks/TestFunctionCallCheck.php
@@ -93,4 +93,12 @@ class TestFunctionCallCheck extends TestSuiteSetup {
 	public function testUnionTypeHints() {
 		$this->assertEquals(1, $this->runAnalyzerOnFile('.9.inc', ErrorConstants::TYPE_SIGNATURE_TYPE));
 	}
+
+	/**
+	 * @return void
+	 * @rapid-unit Checks:FunctionCallCheck:Ensures that passing an object with a __toString method is allowed as a valid argument to a method or function with a string requirement
+	 */
+	public function testObjectWith__toStringMethod() {
+		$this->assertEquals(0, $this->runAnalyzerOnFile('.10.inc', ErrorConstants::TYPE_SIGNATURE_TYPE));
+	}
 }


### PR DESCRIPTION
### Description
- Currently guardrail fails if an object is given to a function or method with a string requirement even if the object implements a `__toString` method.
- This adds a test and fix for the `__toString` issue.