### PR TITLE
Update PSR-4 check to not use substring search

### DIFF
--- a/tests/TestConfig.php
+++ b/tests/TestConfig.php
@@ -25,13 +25,15 @@ class TestConfig extends Config {
 	 * TestConfig constructor.
 	 *
 	 * @param string $file
+	 * @param mixed  $emit
+	 * @param array  $additionalConfig
 	 */
-	public function __construct($file, $emit) {
-		$this->basePath = dirname(realpath($file)) . "/";
-		$this->config = [
+	public function __construct($file, $emit, array $additionalConfig = []) {
+		$this->basePath = $additionalConfig['basePath'] ?? dirname(realpath($file)) . "/";
+		$this->config = array_merge([
 			'test' => [$file],
 			'index' => [dirname($file)],
-		];
+		], $additionalConfig);
 		$this->forceIndex = true;
 		$this->symbolTable = new InMemorySymbolTable($this->basePath);
 		if (!is_array($emit)) {
@@ -76,4 +78,14 @@ class TestConfig extends Config {
 		return $this->emitList;
 	}
 
+	/**
+	 * @return array
+	 */
+	public function getPsrRoots() {
+		// Method has to be overridden by $config is private in the parent class.
+		if (isset($this->config) && array_key_exists('psr-roots', $this->config) && is_array($this->config['psr-roots'])) {
+			return $this->config['psr-roots'];
+		}
+		return [];
+	}
 }

--- a/tests/TestSuiteSetup.php
+++ b/tests/TestSuiteSetup.php
@@ -25,16 +25,22 @@ abstract class TestSuiteSetup extends TestCase {
 	 *
 	 * @param string $fileName
 	 * @param mixed  $emit
-	 *
+	 * @param array  $additionalConfig
 	 * @return int
 	 */
-	public function runAnalyzerOnFile($fileName, $emit) {
-		$output = $this->analyzeFileToOutput($fileName, $emit);
+	public function runAnalyzerOnFile($fileName, $emit, array $additionalConfig = []) {
+		$output = $this->analyzeFileToOutput($fileName, $emit, $additionalConfig);
 
 		return $output->getErrorCount();
 	}
 
-	public function analyzeFileToOutput($fileName, $emit) {
+	/**
+	 * @param string $fileName
+	 * @param mixed  $emit
+	 * @param array  $additionalConfig
+	 * @return XUnitOutput
+	 */
+	public function analyzeFileToOutput($fileName, $emit, array $additionalConfig = []) {
 		$testDataDirectory = $this->getCallerTestDataDirectory($this);
 		if (false === strpos($fileName, $testDataDirectory)) {
 			$fileName = $testDataDirectory . $fileName;
@@ -44,7 +50,7 @@ abstract class TestSuiteSetup extends TestCase {
 			throw new \InvalidArgumentException("That file does not exist. Make sure it follows the NameOfTestClass.#.inc \n pattern and is in the TestData directory of the class file directory.");
 		}
 
-		$config = new TestConfig($fileName, $emit);
+		$config = new TestConfig($fileName, $emit, $additionalConfig);
 		$output = new XUnitOutput($config);
 
 		$indexer = new IndexingPhase($config);

--- a/tests/units/Checks/TestData/TestPsr4Check/Alpha/Eight.php
+++ b/tests/units/Checks/TestData/TestPsr4Check/Alpha/Eight.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Epsilon;
+
+/*
+ * My namespace does not exist. I don't get checked.
+ */
+class Eight {
+
+}

--- a/tests/units/Checks/TestData/TestPsr4Check/Alpha/SDK/One.php
+++ b/tests/units/Checks/TestData/TestPsr4Check/Alpha/SDK/One.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace AlphaSDK;
+
+class One {
+
+}

--- a/tests/units/Checks/TestData/TestPsr4Check/Alpha/SDK/Three.php
+++ b/tests/units/Checks/TestData/TestPsr4Check/Alpha/SDK/Three.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Alpha\SDK;
+
+/*
+ * I'm using a different namespace root than the root assigned my directory. Funky, but legal.
+ */
+class Three {
+
+}

--- a/tests/units/Checks/TestData/TestPsr4Check/Alpha/Two.php
+++ b/tests/units/Checks/TestData/TestPsr4Check/Alpha/Two.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Alpha;
+
+class Two {
+
+}

--- a/tests/units/Checks/TestData/TestPsr4Check/Beta/Five.php
+++ b/tests/units/Checks/TestData/TestPsr4Check/Beta/Five.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace AlphaSDK;
+
+/*
+ * I'm in the wrong directory for my namespace
+ */
+class Five {
+
+}

--- a/tests/units/Checks/TestData/TestPsr4Check/Beta/Gamma/Four.php
+++ b/tests/units/Checks/TestData/TestPsr4Check/Beta/Gamma/Four.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Beta\Gamma;
+
+class Four {
+
+}

--- a/tests/units/Checks/TestData/TestPsr4Check/Delta/Seven.php
+++ b/tests/units/Checks/TestData/TestPsr4Check/Delta/Seven.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Alpha;
+
+/*
+ * I'm in the wrong directory for my namespace
+ */
+class Seven {
+
+}

--- a/tests/units/Checks/TestData/TestPsr4Check/Delta/Six.php
+++ b/tests/units/Checks/TestData/TestPsr4Check/Delta/Six.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Delta;
+
+class Six {
+
+}

--- a/tests/units/Checks/TestPromotedProperties.php
+++ b/tests/units/Checks/TestPromotedProperties.php
@@ -23,7 +23,7 @@ class TestPromotedProperties extends TestSuiteSetup {
 	public function testPromotedPropertyParsing() {
 		$factory=new ParserFactory();
 		$parser = $factory->create(ParserFactory::ONLY_PHP7);
-		$file = file_get_contents("./units/Checks/TestData/TestPromotedProperties.1.inc");
+		$file = file_get_contents(__DIR__ . "/TestData/TestPromotedProperties.1.inc");
 		$tokens = $parser->parse($file);
 
 		$traverser=new NodeTraverser();

--- a/tests/units/Checks/TestPsr4Check.php
+++ b/tests/units/Checks/TestPsr4Check.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace BambooHR\Guardrail\Tests\units\Checks;
+
+use BambooHR\Guardrail\Checks\ErrorConstants;
+use BambooHR\Guardrail\Tests\TestSuiteSetup;
+
+class TestPsr4Check extends TestSuiteSetup {
+
+	/**
+	 * @dataProvider fileProvider
+	 * @param string $file
+	 * @param int    $expectedErrorCount
+	 * @return void
+	 * @rapid-unit   Checks:Psr4:Detects
+	 */
+	public function testCheckBehavior(string $file, int $expectedErrorCount): void {
+		$roots = [
+			'Alpha' => 'TestData/TestPsr4Check/Alpha',
+			'AlphaSDK' => 'TestData/TestPsr4Check/Alpha/SDK',
+			'Beta' => 'TestData/TestPsr4Check/Beta',
+			'App\\Delta' => 'TestData/TestPsr4Check/Delta',
+		];
+		$basePath = __DIR__; // Override the basePath so that namespaces resolve correctly
+		$this->assertEquals(
+			$expectedErrorCount,
+			$this->runAnalyzerOnFile(
+				$file,
+				ErrorConstants::TYPE_PSR4,
+				['basePath' => $basePath, 'psr-roots' => $roots]
+			),
+			'Failed using Guardrail psr-roots'
+		);
+
+		$composerRoots = [];
+		foreach ($roots as $root => $dir) {
+			$composerRoots[$root. '\\'] = $dir;
+		}
+		$this->assertEquals(
+			$expectedErrorCount,
+			$this->runAnalyzerOnFile(
+				$file,
+				ErrorConstants::TYPE_PSR4,
+				['basePath' => $basePath, 'psr-roots' => $composerRoots]
+			),
+			'Failed using composer roots'
+		);
+	}
+
+	/**
+	 * @return string[][]
+	 */
+	public function fileProvider(): array {
+		return [
+			['/Alpha/SDK/One.php', 0],
+			['/Alpha/Two.php', 0],
+			['/Alpha/SDK/Three.php', 0],
+			['/Beta/Gamma/Four.php', 0],
+			['/Beta/Five.php', 1],
+			['/Delta/Six.php', 0],
+			['/Delta/Seven.php', 1],
+			['/Alpha/Eight.php', 0],
+		];
+	}
+}


### PR DESCRIPTION
When a project uses a PSR-4 root name which is also the prefix of
another root name, the Guardrail check may choose the wrong root when
the shorter root appears first in the list. As a result, the PSR-4
check will resolve the wrong expected file path and emit a false
negative. I have updated the expected path resolution logic to mimic
Composer's own algorithm so that it is not affected by root name
combinations like this.

Jira: [GB-947]

[GB-947]: https://bamboohr.atlassian.net/browse/GB-947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ