### PR TITLE
Fix Unknown Method Issues

### DIFF
--- a/tests/units/Checks/AccessingSuperGlobalsTest.php
+++ b/tests/units/Checks/AccessingSuperGlobalsTest.php
@@ -5,11 +5,11 @@ use BambooHR\Guardrail\Checks\ErrorConstants;
 use BambooHR\Guardrail\Tests\TestSuiteSetup;
 
 /**
- * Class AccessingSuperGlobalsCheckTest
+ * Class AccessingSuperGlobalsTest
  *
  * @package BambooHR\Guardrail\Tests\Checks
  */
-class AccessingSuperGlobalsCheckTest extends TestSuiteSetup {
+class AccessingSuperGlobalsTest extends TestSuiteSetup {
 
 	/**
 	 * testRunAccessingSuperGlobalGlobalExpressions

--- a/tests/units/Checks/TestData/TestMethodCallCheck.1.inc
+++ b/tests/units/Checks/TestData/TestMethodCallCheck.1.inc
@@ -1,0 +1,32 @@
+<?php
+
+class TestClassWithMethod {
+	//No errors should be emitted from this method
+	static public function testGetErrorsTernary(Exception $exception): array {
+		return (method_exists($exception, 'getErrors')) ? $exception->getErrors() : [];
+	}
+
+	//No errors should be emitted from this method
+	static public function testGetErrorsConditional(Exception $exception): array {
+		$errors = [];
+		if (method_exists($exception, 'getErrors')) {
+			$errors = $exception->getErrors();
+		}
+
+		return $errors;
+	}
+
+	//This method should emit a ErrorConstants::TYPE_UNKNOWN_METHOD due to the second conditional
+	static public function testGetErrorsConditionalWrongMethodCheck(Exception $exception, bool $somethingElse): array {
+		//Add another conditional just to make sure the logic is correct in MethodCall.php
+		if ($somethingElse || method_exists($exception, 'getErrors')) {
+			return [];
+		}
+		$errors = [];
+		if (method_exists($exception, 'getFailures')) { //This should emit a ErrorConstants::TYPE_UNKNOWN_METHOD
+			$errors = $exception->getErrors();
+		}
+
+		return $errors;
+	}
+}

--- a/tests/units/Checks/TestMethodCallCheck.php
+++ b/tests/units/Checks/TestMethodCallCheck.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace BambooHR\Guardrail\Tests\units\Checks;
+
+use BambooHR\Guardrail\Checks\ErrorConstants;
+use BambooHR\Guardrail\Tests\TestSuiteSetup;
+
+/**
+ * Class TestMethodCallCheck
+ *
+ * @package BambooHR\Guardrail\Tests\units\Checks
+ */
+class TestMethodCallCheck extends TestSuiteSetup {
+	/**
+	 * Test an unknown method check on a class with a method_exists() check prior to calling the method. See TestMethodCallCheck.1.inc for the example class.
+	 * If method_exists() is called before invoking a method on an object, an ErrorConstants::TYPE_UNKNOWN_METHOD shouldn't be omitted.
+	 *
+	 * @return void
+	 */
+	public function testUnknownMethodWithExistsCheck(): void {
+		$this->assertEquals(1, $this->runAnalyzerOnFile('.1.inc', ErrorConstants::TYPE_UNKNOWN_METHOD));
+	}
+}


### PR DESCRIPTION
### Description
- When checking in with the `method_exists()` function prior to calling a method on an object guardrail was previously throwing the `Standard.Unknown.Class.Method` error.
- This commit addresses that issue by checking for a `method_exists()` check in a conditional surrounding the method call. If the method being checked matches the one being invoked on the object we don't need to emit an error.
- Included a a fix for `AccessingSuperGlobalsTest.php` so the test would run properly.