### PR TITLE
Mixed return type for php 8

### DIFF
--- a/src/Checks/ParamTypesCheck.php
+++ b/src/Checks/ParamTypesCheck.php
@@ -60,7 +60,7 @@ class ParamTypesCheck extends BaseCheck {
 	 */
 	private function getNullableTypeName($type) {
 		$type = $type instanceof Node\NullableType ? $type->type : $type;
-		return $type instanceof UnionType ? 'object' : strval($type);
+		return $type instanceof UnionType ? 'mixed' : strval($type);
 	}
 
 	/**

--- a/src/NodeVisitors/StaticAnalyzer.php
+++ b/src/NodeVisitors/StaticAnalyzer.php
@@ -343,8 +343,11 @@ class StaticAnalyzer extends NodeVisitorAbstract {
 		};
 
 		$func[Node\Stmt\Catch_::class] = function (Node\Stmt\Catch_ $node) {
-			$this->setScopeType(strval($node->var->name), count($node->types)==1 ? strval($node->types[0]) : Scope::MIXED_TYPE, $node->getLine());
-			$this->setScopeUsed(strval($node->var->name));
+			// Variable names are optional in a catch(). If specified, add them to the scope.
+			if($node->var) {
+				$this->setScopeType(strval($node->var->name), count($node->types) == 1 ? strval($node->types[0]) : Scope::MIXED_TYPE, $node->getLine());
+				$this->setScopeUsed(strval($node->var->name));
+			}
 		};
 
 		$func[Node\Stmt\Global_::class] = function (Node\Stmt\Global_ $node) {
@@ -1026,7 +1029,7 @@ class StaticAnalyzer extends NodeVisitorAbstract {
 
 	/**
 	 * @param Node\Arg[]   $args
-	 * @param Node\Param[] $params
+	 * @param FunctionLikeParameter[] $params
 	 */
 	private function addReferenceParametersToLocalScope(array $args, array $params) {
 		$paramCount = count($params);

--- a/src/Util.php
+++ b/src/Util.php
@@ -56,7 +56,7 @@ class Util {
 	 * @return bool
 	 */
 	static public function isLegalNonObject($name) {
-		return self::isScalarType($name) || strcasecmp($name, "callable") == 0 || strcasecmp($name, "iterable") == 0 || strcasecmp($name, "array") == 0 || strcasecmp($name, "void") == 0 || strcasecmp($name, "null") == 0 || strcasecmp($name,"resource") == 0 || strcasecmp($name,"object")==0;
+		return self::isScalarType($name) || strcasecmp($name,"mixed") == 0 || strcasecmp($name, "callable") == 0 || strcasecmp($name, "iterable") == 0 || strcasecmp($name, "array") == 0 || strcasecmp($name, "void") == 0 || strcasecmp($name, "null") == 0 || strcasecmp($name,"resource") == 0 || strcasecmp($name,"object")==0;
 	}
 
 	/**


### PR DESCRIPTION
Support for explicitly returning mixed from a method.  Also, compound return types are treated as mixed.  Support for omitting variable from exception catches.