### PR TITLE
Property promotion fix

### DIFF
--- a/src/NodeVisitors/PromotedPropertyVisitor.php
+++ b/src/NodeVisitors/PromotedPropertyVisitor.php
@@ -64,8 +64,8 @@ class PromotedPropertyVisitor extends NodeVisitorAbstract {
 		if($param->flags & Class_::MODIFIER_PROTECTED) {
 			$prop->makeProtected();
 		}
-		if($param->getType()) {
-			$prop->setType( $param->getType() );
+		if($param->type) {
+			$prop->setType( $param->type );
 		}
 
 		$propNode = $prop->getNode();


### PR DESCRIPTION
Fix for property promotion.  When copying the type make sure to use $param->type instead of $param->getType().  The latter always returns "Param";