### PR TITLE
Method Call Fix

### DIFF
--- a/tests/units/Checks/TestData/TestMethodCallCheck.2.inc
+++ b/tests/units/Checks/TestData/TestMethodCallCheck.2.inc
@@ -1,0 +1,18 @@
+<?php
+
+class TestClass {
+	protected function logException(?Exception $logException = null) {
+		if ($logException) {
+			$log = [ 'exception' => [
+				'exception' => get_class($logException),
+				'code' => $logException->getCode(),
+				'additionalExceptionInfo' => method_exists($logException, 'getNatureOfError') ? $logException->getNatureOfError() : null, //This should not emit a ErrorConstants::TYPE_UNKNOWN_METHOD
+				'file' => $logException->getFile(),
+				'line' => $logException->getLine(),
+				'trace' => $logException->getTraceAsString(),
+				'something' => $logException->something(), //This should emit a ErrorConstants::TYPE_UNKNOWN_METHOD
+			]];
+		}
+		return $log;
+	}
+}

--- a/tests/units/Checks/TestMethodCallCheck.php
+++ b/tests/units/Checks/TestMethodCallCheck.php
@@ -20,4 +20,13 @@ class TestMethodCallCheck extends TestSuiteSetup {
 	public function testUnknownMethodWithExistsCheck(): void {
 		$this->assertEquals(1, $this->runAnalyzerOnFile('.1.inc', ErrorConstants::TYPE_UNKNOWN_METHOD));
 	}
+
+	/**
+	 * Test that using method_exists doesn't break guardrail. See TestMethodCallCheck.2.inc for the example class.
+	 *
+	 * @return void
+	 */
+	public function testMethodExistsDoesntBreak(): void {
+		$this->assertEquals(1, $this->runAnalyzerOnFile('.2.inc', ErrorConstants::TYPE_UNKNOWN_METHOD));
+	}
 }


### PR DESCRIPTION
### Description
- When dealing with nested nodes, the existing check choked.
- Fix by traversing all possible trees and looking for the cond/name/parts node that match the criteria.