### PR TITLE
A Small Fix to the MethodCall Check

### DIFF
--- a/src/Checks/MethodCall.php
+++ b/src/Checks/MethodCall.php
@@ -192,7 +192,7 @@ class MethodCall extends CallCheck {
 		foreach (['stmts', 'items', 'expr'] as $nodeType) {
 			if ($this->checkNodeForSubNodeNames($tmpStmt, $nodeType)) {
 				foreach ($tmpStmt->$nodeType as $stmtInner) {
-					if ($this->checkForMethodExists($node, $stmtInner)) {
+					if ($stmtInner instanceof Node && $this->checkForMethodExists($node, $stmtInner)) {
 						return true;
 					}
 				}


### PR DESCRIPTION
### Description
While running against the payroll gateway repository this was uncovered. We need to ensure that the inner statement is a `Node` object before recursively calling the method.