### PR TITLE
[SPEED-694] Make fixes/improvements to our InterfaceCheck

### DIFF
--- a/src/Evaluators/FunctionLike.php
+++ b/src/Evaluators/FunctionLike.php
@@ -133,20 +133,22 @@ class FunctionLike implements OnEnterEvaluatorInterface, OnExitEvaluatorInterfac
 	 * @return void
 	 */
 	public function updateFunctionEmit(Node\FunctionLike $func, ScopeStack $scopeStack, $pushOrPop) {
+		$docBlock = $func->getDocComment();
+		if (!empty($docBlock)) {
+			$docBlock = trim($docBlock);
+			$ignoreList = [];
 
-		$docBlock = trim($func->getDocComment());
-		$ignoreList = [];
-
-		if (preg_match_all("/@guardrail-ignore ([A-Za-z. ,]*)/", $docBlock, $ignoreList)) {
-			foreach ($ignoreList[1] as $ignoreListEntry) {
-				$toIgnore = explode(",", $ignoreListEntry);
-				foreach ($toIgnore as $type) {
-					$type = trim($type);
-					if (!empty($type)) {
-						if ($pushOrPop == "push") {
-							$scopeStack->getOutput()->silenceType($type);
-						} else {
-							$scopeStack->getOutput()->resumeType($type);
+			if (preg_match_all("/@guardrail-ignore ([A-Za-z. ,]*)/", $docBlock, $ignoreList)) {
+				foreach ($ignoreList[1] as $ignoreListEntry) {
+					$toIgnore = explode(",", $ignoreListEntry);
+					foreach ($toIgnore as $type) {
+						$type = trim($type);
+						if (!empty($type)) {
+							if ($pushOrPop == "push") {
+								$scopeStack->getOutput()->silenceType($type);
+							} else {
+								$scopeStack->getOutput()->resumeType($type);
+							}
 						}
 					}
 				}

--- a/src/TypeComparer.php
+++ b/src/TypeComparer.php
@@ -138,10 +138,8 @@ class TypeComparer
 
 	static function typeToString(ComplexType|Name|Identifier|null $type):string {
 		if ($type === null) {
-			return "";
-		} else if($type instanceof Name) {
-			return strval($type);
-		} else if($type instanceof Identifier) {
+			return "mixed";
+		} else if($type instanceof Name || $type instanceof  Identifier) {
 			return strval($type);
 		} else if($type instanceof Node\NullableType) {
 			return "(null|".strval($type->type).")";

--- a/tests/units/Checks/TestData/TestInterfaceCheck.7.inc
+++ b/tests/units/Checks/TestData/TestInterfaceCheck.7.inc
@@ -1,0 +1,14 @@
+<?php
+
+interface parentClass {
+	public function method1(int $param1, string $param2): bool;
+	public function method2($param1, array $param2): string;
+}
+class childClass implements parentClass {
+	public function method1($param1, $param2): bool {
+		return true;
+	}
+	public function method2(mixed $param1, mixed $param2): mixed {
+		return;
+	}
+}

--- a/tests/units/Checks/TestData/TestInterfaceCheck.8.inc
+++ b/tests/units/Checks/TestData/TestInterfaceCheck.8.inc
@@ -1,0 +1,14 @@
+<?php
+
+interface parentClass {
+	public function method1(mixed $param1, mixed $param2);
+	public function method2($param1, $param2);
+}
+class childClass implements parentClass {
+	public function method1($param1, $param2) {
+		return;
+	}
+	public function method2(mixed $param1, mixed $param2) {
+		return;
+	}
+}

--- a/tests/units/Checks/TestData/TestInterfaceCheck.9.inc
+++ b/tests/units/Checks/TestData/TestInterfaceCheck.9.inc
@@ -1,0 +1,23 @@
+<?php
+
+interface parentClass {
+	public function method1(): bool;
+	public function method2(): mixed;
+	public function method3();
+	public function method4(): string;
+}
+class childClass implements parentClass {
+	/** This should not work because int is different than bool */
+	public function method1(): int {
+		return true;
+	}
+	public function method2(): string {
+		return "";
+	}
+	public function method3(): int {
+		return 1;
+	}
+	public function method4(): string {
+		return "1";
+	}
+}

--- a/tests/units/Checks/TestInterfaceCheck.php
+++ b/tests/units/Checks/TestInterfaceCheck.php
@@ -70,4 +70,32 @@ class TestInterfaceCheck extends TestSuiteSetup {
 	public function testSameSignatureDifferentVisibilityValid() {
 		$this->assertEquals(0, $this->runAnalyzerOnFile('.6.inc', ErrorConstants::TYPE_SIGNATURE_TYPE));
 	}
+
+	/**
+	 * Test that parameter type can be less specific in a child method, than that of its parent
+	 *
+	 * @return void
+	 */
+	public function testMethodParameterContravariance() {
+		$this->assertEquals(0, $this->runAnalyzerOnFile('.7.inc', ErrorConstants::TYPE_SIGNATURE_TYPE));
+	}
+
+	/**
+	 * A class that implements another is ok to have a type not defined when the parent type is mixed and the child class
+	 * is ok to have a mixed type when the parent type is not defined. (mixed and not defined behave the same)
+	 *
+	 * @return void
+	 */
+	public function testMixedAndNoTypeAreTheSame() {
+		$this->assertEquals(0, $this->runAnalyzerOnFile('.8.inc', ErrorConstants::TYPE_SIGNATURE_TYPE));
+	}
+
+	/**
+	 * A child method should be able to return a more specific type than the return type of its parent method.
+	 *
+	 * @return void
+	 */
+	public function testCovarianceOfReturnTypes() {
+		$this->assertEquals(1, $this->runAnalyzerOnFile('.9.inc', ErrorConstants::TYPE_SIGNATURE_RETURN));
+	}
 }


### PR DESCRIPTION
* Added a new check with a test (TestInterfaceCheck.9.inc) to make sure that child method and parent method return types mesh together. In php a child method should be able to return a more specific type than the return type of its parent method. So the check ensures that either the return types are the same between the child and parent or the parent type is mixed or undefined (in which case the child return type can be anything)
* Changed the TypeComparer::typeToString to return "mixed" if the param type is undefined because no parameter should be treated the same as mixed. I added a test for this case (TestInterfaceCheck.8.inc)
* The new version of guardrail (jgardiner/union-types) in some cases is now finding accurate param types from php extension files. This means that the interfaceCheck is failing for files that implement these php extensions. The fix for this is on line 95 of the InterfaceCheck.php where we dont emmit an error if the child param type is equal to "mixed". Php allows parameter types in a child method to be less specific than that of the parent method. This means that a child class can have type mixed or undefined where the parent is defined as something more specific like a string or int. This new behavior is tested in the testMethodParameterContravariance method (TestInterfaceCheck.7.inc)
* Added an empty check to the FunctionLike updateFunctionEmit method to eliminate the deprecated warnings when there is no doc comment for a method.
* renamed variables in the InterfaceCheck to be more clear on what they are