### PR TITLE
Adding Enum Support For AutoLoad Check

### DIFF
--- a/src/Phases/AnalyzingPhase.php
+++ b/src/Phases/AnalyzingPhase.php
@@ -26,6 +26,7 @@ use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Nop;
 use PhpParser\Node\Stmt\Trait_;
 use PhpParser\Node\Stmt\Use_;
+use PhpParser\Node\Stmt\Enum_;
 use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\ParserFactory;
 use PhpParser\NodeTraverser;
@@ -168,6 +169,7 @@ class AnalyzingPhase {
 			$node instanceof Use_ ||
 			$node instanceof Node\Stmt\GroupUse ||
 			$node instanceof Comment ||
+			$node instanceof Enum_ ||
 			$node instanceof Node\Stmt\Declare_
 		) {
 			return true;


### PR DESCRIPTION
Adding support for Enums in AutoLoad Check.

### Testing Notes:

**Reproduce Issue:**
- On `main` repo, checked out branch with enum via `git checkout ebf6c296071a76b9916c34866f8adffac6154237`
- Pulled Latest `guardrail` repo
- On guardrail repo, generated guardrail.phar via `src/bin/Build.sh`
- Moved generated phar to `main` repo
- In `main` repo, Ran local test via `php guardrail.phar -i -j -n 10 sa.json && php guardrail.phar -a -j -n 10 sa.json > myCSV.csv`
- Notice autoload failure related to enums in `myCSV.csv`

**Fix and test issue**
- Made change in local `guardrail` branch
- On `guardrail` repo, generated guardrail.phar via `src/bin/Build.sh`
- Moved generated phar to main repo
- On `main` repo, checked out branch with enum via `git checkout ebf6c296071a76b9916c34866f8adffac6154237`
- In `main` repo,  Ran local test via `php guardrail.phar -i -j -n 10 sa.json && php guardrail.phar -a -j -n 10 sa.json > myCSV.csv`
- Notice no more autoload failure related to enums in `myCSV.csv`
