### PR TITLE
[SPEED-994] Fix Covariance Return Type bug with objects

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -36,7 +36,7 @@ class Config {
 	private $reindex = false;
 
 	/** @var array nested array with the settings for what files to import */
-	private $config = [];
+	protected $config = [];
 
 	/** @var string */
 	private $symbolTableFile = "symbol_table";
@@ -100,7 +100,7 @@ class Config {
 	/**
 	 * @return void
 	 */
-	private function loadConfigVars() {
+	protected function loadConfigVars() {
 		if (isset($this->config) && array_key_exists('options', $this->config) && is_array($this->config['options'])) {
 			foreach ($this->config['options'] as $key => $value) {
 				if ($value === true) {

--- a/tests/TestConfig.php
+++ b/tests/TestConfig.php
@@ -10,15 +10,10 @@ use BambooHR\Guardrail\SymbolTable\SymbolTable;
  * @package BambooHR\Guardrail\Tests
  */
 class TestConfig extends Config {
-
 	public $basePath;
-
-	public $config;
-
+	protected $config;
 	public $symbolTable;
-
 	public $emitList;
-
 	public $forceIndex;
 
 	/**
@@ -31,9 +26,16 @@ class TestConfig extends Config {
 	public function __construct($file, $emit, array $additionalConfig = []) {
 		$this->basePath = $additionalConfig['basePath'] ?? dirname(realpath($file)) . "/";
 		$this->config = array_merge([
+			'options' => [
+				"DocBlockReturns" => true,
+				"DocBlockParams" => true,
+				"DocBlockInlineVars" => true,
+				"DocBlockProperties" => true,
+			],
 			'test' => [$file],
 			'index' => [dirname($file)],
 		], $additionalConfig);
+		$this->loadConfigVars();
 		$this->forceIndex = true;
 		$this->symbolTable = new InMemorySymbolTable($this->basePath);
 		if (!is_array($emit)) {
@@ -86,6 +88,7 @@ class TestConfig extends Config {
 		if (isset($this->config) && array_key_exists('psr-roots', $this->config) && is_array($this->config['psr-roots'])) {
 			return $this->config['psr-roots'];
 		}
+
 		return [];
 	}
 }

--- a/tests/units/Checks/TestData/TestInterfaceCheck.9.inc
+++ b/tests/units/Checks/TestData/TestInterfaceCheck.9.inc
@@ -1,8 +1,11 @@
 <?php
 
 
-class dataObject {
+class parentDataObject {
 	public $test;
+}
+class childDataObject extends parentDataObject {
+	public $string;
 }
 interface parentClass {
 	public function method1(): bool;
@@ -13,7 +16,9 @@ interface parentClass {
 	public function method6(): string|int|null;
 	public function method7(): ?int;
 	public function method8(): string|int|null;
-	public function method9() : ?dataObject;
+	public function method9() : ?parentDataObject;
+	public function method10() : parentDataObject;
+	public function method11(): parentDataObject|int|null;
 }
 
 class childClass implements parentClass {
@@ -43,7 +48,17 @@ class childClass implements parentClass {
 	public function method8(): ?bool {
 		return null;
 	}
-	public function method9(): dataObject {
-		return new dataObject();
+
+	public function method9(): parentDataObject {
+		return new parentDataObject();
+	}
+
+	public function method10(): childDataObject {
+		return new childDataObject();
+	}
+
+	/** This should not work because bool is not one of the parent types */
+	public function method11(): bool|childDataObject {
+		return true;
 	}
 }

--- a/tests/units/Checks/TestData/TestPropertyFetchCheck.1.inc
+++ b/tests/units/Checks/TestData/TestPropertyFetchCheck.1.inc
@@ -1,12 +1,17 @@
 <?php
 
-class PropertyFetchCheckClass1 {
+class ParentPropertyFetchCheckClass1 {
+
+}
+class PropertyFetchCheckClass1 extends ParentPropertyFetchCheckClass1 {
 	private $private;
 	protected $protected;
+	public $public;
 
 	public function __construct() {
 		$this->private = 'private';
 		$this->protected = 'protected';
+		$this->public = 'public';
 	}
 
 	public function testMethod() {
@@ -19,3 +24,14 @@ $propertyFetchCheckClass1->private;
 $propertyFetchCheckClass1->protected;
 $propertyFetchCheckClass1->unknown;
 $propertyFetchCheckClass1->testMethod; //emits both TYPE_INCORRECT_DYNAMIC_CALL and TYPE_UNKNOWN_PROPERTY
+
+class testClass {
+	function getPropertyFetchCheckClass1(): ParentPropertyFetchCheckClass1 {
+		return new PropertyFetchCheckClass1();
+	}
+	function testFunc() {
+		$parent = $this->getPropertyFetchCheckClass1();
+		/** @var PropertyFetchCheckClass1 $parent */
+		$parent->public;
+	}
+}

--- a/tests/units/Checks/TestInterfaceCheck.php
+++ b/tests/units/Checks/TestInterfaceCheck.php
@@ -96,7 +96,7 @@ class TestInterfaceCheck extends TestSuiteSetup {
 	 * @return void
 	 */
 	public function testCovarianceOfReturnTypes() {
-		$this->assertEquals(2, $this->runAnalyzerOnFile('.9.inc', ErrorConstants::TYPE_SIGNATURE_RETURN));
+		$this->assertEquals(3, $this->runAnalyzerOnFile('.9.inc', ErrorConstants::TYPE_SIGNATURE_RETURN));
 	}
 
 	public function testIterableIsRespectedForArrayType() {

--- a/tests/units/Checks/TestPropertyFetchCheck.php
+++ b/tests/units/Checks/TestPropertyFetchCheck.php
@@ -19,5 +19,7 @@ class TestPropertyFetchCheck extends TestSuiteSetup {
 	 */
 	public function testAccessingDeclaredPrivateAndProtectedMemberNo__get() {
 		$this->assertEquals(2, $this->runAnalyzerOnFile('.1.inc', ErrorConstants::TYPE_ACCESS_VIOLATION));
+		$this->assertEquals(2, $this->runAnalyzerOnFile('.1.inc', ErrorConstants::TYPE_UNKNOWN_PROPERTY));
+		$this->assertEquals(1, $this->runAnalyzerOnFile('.1.inc', ErrorConstants::TYPE_INCORRECT_DYNAMIC_CALL));
 	}
 }


### PR DESCRIPTION
Added tests to cover cases that were breaking before. The important part of this PR is in the src/Checks/InterfaceCheck.php class where we check to see if the return type is an instance of the parent class and if it is then we ignore it. Additionally there were some changes that I had to make to tests/TestConfig.php, and src/Config.php to get the doc comment options working for tests.