### PR TITLE
feat: collection emptiness check

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Guardrail classifies checks by name.  Here is the standard list of errors.  Note
 | Standard.Autoload.Unsafe            | Code that executes any statements other than a class declaration.                                            |
 | Standard.ConditionalAssignment      | Assigning a variable in conditional expression of an if() statement.                                         |
 | Standard.Constructor.MissingCall    | Overriding a constructor without calling the parent constructor                                              |
+| Standard.Countable.Emptiness        | Use of `empty()` to check if a countable is empty or not                                                     |
 | Standard.Debug                      | Typical debug statements such as var_dump() or print_r()                                                     |
 | Standard.Deprecated.Internal        | Call to an internal PHP function that is deprecated                                                          |
 | Standard.Deprecated.User            | Call to a user function that has @deprecated in the docblock.                                                |

--- a/src/Checks/CountableEmptinessCheck.php
+++ b/src/Checks/CountableEmptinessCheck.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace BambooHR\Guardrail\Checks;
+
+use BambooHR\Guardrail\Checks\BaseCheck;
+use BambooHR\Guardrail\Scope;
+use BambooHR\Guardrail\TypeComparer;
+use Countable;
+use PhpParser\Node;
+use PhpParser\Node\Expr\Empty_;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\ClassLike;
+
+class CountableEmptinessCheck extends BaseCheck {
+	/**
+	 * @return string[]
+	 */
+	function getCheckNodeTypes() {
+		return [Empty_::class];
+	}
+
+	function run($fileName, Node $node, ClassLike $inside = null, Scope $scope = null) {
+		$type = $node->expr->getAttribute(TypeComparer::INFERRED_TYPE_ATTR);
+
+		if (!($type instanceof Name)) {
+			return;
+		}
+
+		if ($this->symbolTable->isParentClassOrInterface(Countable::class, $type)) {
+			$this->emitError(
+				$fileName,
+				$node,
+				ErrorConstants::TYPE_COUNTABLE_EMPTINESS_CHECK,
+				"Attempt to call empty() on a countable, will yield unexpected result. Use `isEmpty()` instead."
+			);
+		}
+	}
+}

--- a/src/Checks/ErrorConstants.php
+++ b/src/Checks/ErrorConstants.php
@@ -1,4 +1,6 @@
-<?php namespace BambooHR\Guardrail\Checks;
+<?php
+
+namespace BambooHR\Guardrail\Checks;
 
 /**
  * Class ErrorConstants
@@ -76,7 +78,7 @@ class ErrorConstants {
 	const TYPE_USE_CASE_SENSITIVE = 'Standard.Use.CaseSensitive';
 	const TYPE_VARIABLE_FUNCTION_NAME = 'Standard.VariableFunctionCall';
 	const TYPE_VARIABLE_VARIABLE = 'Standard.VariableVariable';
-
+	const TYPE_COUNTABLE_EMPTINESS_CHECK = 'Standard.Countable.Emptiness';
 
 
 	/**

--- a/src/CommandLineRunner.php
+++ b/src/CommandLineRunner.php
@@ -65,6 +65,7 @@ where: -p #/#                 = Define the number of partitions and the current 
 
 		set_time_limit(0);
 		date_default_timezone_set("UTC");
+		error_reporting(E_WARNING | E_ERROR);
 
 		if (!extension_loaded("pcntl")) {
 			echo "Guardrail requires the pcntl extension, which is not loaded.\n";

--- a/src/NodeVisitors/StaticAnalyzer.php
+++ b/src/NodeVisitors/StaticAnalyzer.php
@@ -14,6 +14,7 @@ use BambooHR\Guardrail\Checks\ClassConstCheck;
 use BambooHR\Guardrail\Checks\ClassMethodStringCheck;
 use BambooHR\Guardrail\Checks\ConditionalAssignmentCheck;
 use BambooHR\Guardrail\Checks\ConstructorCheck;
+use BambooHR\Guardrail\Checks\CountableEmptinessCheck;
 use BambooHR\Guardrail\Checks\CyclomaticComplexityCheck;
 use BambooHR\Guardrail\Checks\DefinedConstantCheck;
 use BambooHR\Guardrail\Checks\DocBlockTypesCheck;
@@ -153,6 +154,7 @@ class StaticAnalyzer extends NodeVisitorAbstract
 			new ReadOnlyPropertyCheck($this->index, $output),
 			new ClassConstCheck($this->index, $output),
 			new ThrowsCheck($this->index, $output),
+			new CountableEmptinessCheck($this->index, $output),
 			//new ClassStoredAsVariableCheck($this->index, $output)
 		];
 

--- a/tests/units/Checks/TestCountableEmptinessCheck.php
+++ b/tests/units/Checks/TestCountableEmptinessCheck.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace BambooHR\Guardrail\Tests\Checks;
+
+use BambooHR\Guardrail\Checks\ErrorConstants;
+use BambooHR\Guardrail\Tests\TestSuiteSetup;
+
+/**
+ *
+ * @package BambooHR\Guardrail\Tests\Checks
+ */
+class TestCountableEmptinessCheck extends TestSuiteSetup {
+	/**
+	 * testUseIsEmptyInsteadOfEmtpyWarning
+	 *
+	 * @return void
+	 * @rapid-unit Checks:CountableEmptinessCheck:Emits error when using empty() on a countable
+	 */
+	public function testUseIsEmptyInsteadOfEmtpyWarning() {
+		$output = $this->runAnalyzerOnFile('.1.inc', ErrorConstants::TYPE_COUNTABLE_EMPTINESS_CHECK);
+		$this->assertEquals(1, $output, "Expects emptiness check to fail");
+	}
+
+	/**
+	 * runAnalyzerOnFile
+	 *
+	 * @return void
+	 * @rapid-unit Checks:CountableEmptinessCheck:Does not emit errors when using ->isEmpty() on a countable
+	 */
+	public function testCorrectEmptinessCheck() {
+		$output = $this->runAnalyzerOnFile('.2.inc', ErrorConstants::TYPE_COUNTABLE_EMPTINESS_CHECK);
+		$this->assertEquals(0, $output, "Expects emptiness check to pass");
+	}
+}

--- a/tests/units/Checks/TestData/TestCountableEmptinessCheck.1.inc
+++ b/tests/units/Checks/TestData/TestCountableEmptinessCheck.1.inc
@@ -1,0 +1,15 @@
+<?php
+
+class MyCountable implements Countable {
+	public function count(): int {
+		return 0;
+	}
+}
+
+class Test {
+	function foo() {
+		$emptyCountable = new MyCountable();
+
+		empty($emptyCountable);
+	}
+}

--- a/tests/units/Checks/TestData/TestCountableEmptinessCheck.2.inc
+++ b/tests/units/Checks/TestData/TestCountableEmptinessCheck.2.inc
@@ -1,0 +1,19 @@
+<?php
+
+class MyCountable implements Countable {
+	public function count(): int {
+		return 0;
+	}
+
+	public function isEmpty(): bool {
+		return true;
+	}
+}
+
+class Test {
+	function foo() {
+		$emptyCountable = new MyCountable();
+
+		$emptyCountable->isEmpty();
+	}
+}


### PR DESCRIPTION
checks usage of `empty` to check if a countable has elements or not