### PR TITLE
docs: improve wording for emptiness check warning

### DIFF
--- a/src/Checks/CountableEmptinessCheck.php
+++ b/src/Checks/CountableEmptinessCheck.php
@@ -31,7 +31,7 @@ class CountableEmptinessCheck extends BaseCheck {
 				$fileName,
 				$node,
 				ErrorConstants::TYPE_COUNTABLE_EMPTINESS_CHECK,
-				"Attempt to call empty() on a countable, will yield unexpected result. Use `isEmpty()` instead."
+				"Attempt to call empty() on a countable, will yield unexpected result. Use `isEmpty()`, `isNotEmpty()` or `count()` instead."
 			);
 		}
 	}


### PR DESCRIPTION
suggest `count()` or `isEmpty()` / `isNotEmpty()` as possible fix for
the emptiness warning.