### PR TITLE
Check interfaces that extend other interfaces.  

### DIFF
--- a/src/Util.php
+++ b/src/Util.php
@@ -225,6 +225,23 @@ class Util {
 		return null;
 	}
 
+	static public function findAllInterfaces(string $className, SymbolTable $symbolTable):array {
+		$interfaces = [];
+		while ($className) {
+			$class = $symbolTable->getAbstractedClass($className);
+			if (!$class) {
+				return $interfaces;
+			}
+			$immediateList = $class->getInterfaceNames();
+			foreach($immediateList as $immediate ) {
+				$childInterfaces = static::findAllInterfaces($immediate, $symbolTable);
+				$interfaces = [ ...$childInterfaces, $immediate, ...$interfaces];
+			}
+			$className = $class->getParentClassName();
+		}
+ 		return array_unique($interfaces);
+	}
+
 	static function findAbstractedConstantExpr(string $className, string $constantName, SymbolTable $symbolTable) {
 		while ($className) {
 			$class = $symbolTable->getAbstractedClass($className);


### PR DESCRIPTION
If both list a method, then the signature must be compatible.

- Check interfaces "implemented" by an abstract base class.  The base class doesn't need to actually implement, any non-abstract classes do.