### PR TITLE
Detect more trait related errors

### DIFF
--- a/src/Checks/DuplicateMemberCheck.php
+++ b/src/Checks/DuplicateMemberCheck.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace BambooHR\Guardrail\Checks;
+
+use BambooHR\Guardrail\Output\OutputInterface;
+use BambooHR\Guardrail\Scope;
+use BambooHR\Guardrail\SymbolTable\SymbolTable;
+use PhpParser\Builder\Interface_;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\Enum_;
+
+class DuplicateMemberCheck extends BaseCheck {
+
+	function getCheckNodeTypes() {
+		return [ Class_::class, Interface_::class, Enum_::class];
+	}
+
+	function run($fileName, Node $node, ClassLike $inside = null, Scope $scope = null) {
+		if ($node instanceof ClassLike) {
+			$members = ["method"=>[], "property"=>[], "constant"=>[]];
+
+			foreach ($node->stmts as $stmt) {
+				if ($stmt instanceof Node\Stmt\ClassMethod) {
+					$this->addOrEmitError($fileName, $stmt, $members, $stmt->name->name, "method");
+				} else if ($stmt instanceof Node\Stmt\Property) {
+					foreach ($stmt->props as $prop) {
+						$this->addOrEmitError($fileName, $prop, $members, $prop->name->name, "property");
+					}
+				} else if ($stmt instanceof Node\Stmt\ClassConst) {
+					foreach ($stmt->consts as $const) {
+						$this->addOrEmitError($fileName, $const, $members, $const->name->name, "constant");
+					}
+				}
+			}
+		}
+	}
+
+	function addOrEmitError(string $fileName, Node $node, array &$members, string $name,string $type) {
+		$normalizedName = ($type == 'method') ? strtolower($name) : $name;
+		if (!isset($members[$type][$normalizedName])) {
+			$members[$type][$normalizedName] = $node->getLine();
+		} else {
+			$this->emitError($fileName, $node, ErrorConstants::TYPE_DUPLICATE_NAME, "Duplicate $type " . $name . " first declared on line " . $members[$type][$normalizedName]);
+		}
+	}
+}

--- a/src/Checks/ErrorConstants.php
+++ b/src/Checks/ErrorConstants.php
@@ -60,6 +60,7 @@ class ErrorConstants {
 	const TYPE_UNIMPLEMENTED_METHOD = 'Standard.Inheritance.Unimplemented';
 	const TYPE_UNKNOWN_CLASS = 'Standard.Unknown.Class';
 	const TYPE_OVERRIDE_BASE_CLASS = 'Standard.Override.Base';
+	const TYPE_DUPLICATE_NAME = 'Standard.Duplicate.Name';
 
 	const TYPE_UNDOCUMENTED_EXCEPTION = 'Standard.Undocumented.Exception';
 

--- a/src/NodeVisitors/StaticAnalyzer.php
+++ b/src/NodeVisitors/StaticAnalyzer.php
@@ -18,6 +18,7 @@ use BambooHR\Guardrail\Checks\CountableEmptinessCheck;
 use BambooHR\Guardrail\Checks\CyclomaticComplexityCheck;
 use BambooHR\Guardrail\Checks\DefinedConstantCheck;
 use BambooHR\Guardrail\Checks\DocBlockTypesCheck;
+use BambooHR\Guardrail\Checks\DuplicateMemberCheck;
 use BambooHR\Guardrail\Checks\EnumCheck;
 use BambooHR\Guardrail\Checks\FunctionCallCheck;
 use BambooHR\Guardrail\Checks\GotoCheck;
@@ -158,6 +159,7 @@ class StaticAnalyzer extends NodeVisitorAbstract
 			new ThrowsCheck($this->index, $output),
 			new CountableEmptinessCheck($this->index, $output),
 			new DependenciesOnVendorCheck($this->index, $output, $metricOutput),
+			new DuplicateMemberCheck($this->index, $output),
 			//new ClassStoredAsVariableCheck($this->index, $output)
 		];
 

--- a/src/NodeVisitors/TraitImportingVisitor.php
+++ b/src/NodeVisitors/TraitImportingVisitor.php
@@ -26,11 +26,6 @@ class TraitImportingVisitor extends NodeVisitorAbstract {
 
 
 	/**
-	 * @var array
-	 */
-	private $classStack = [];
-
-	/**
 	 * TraitImportingVisitor constructor.
 	 *
 	 * @param SymbolTable $index Instance of SymbolTable
@@ -39,37 +34,16 @@ class TraitImportingVisitor extends NodeVisitorAbstract {
 		$this->importer  = new TraitImporter($index);
 	}
 
-
-	/**
-	 * enterNode
-	 *
-	 * @param Node $node Instance of Node
-	 *
-	 * @return null
-	 */
-	public function enterNode(Node $node) {
-		if ($node instanceof Class_ || $node instanceof Trait_ || $node instanceof Node\Stmt\Enum_) {
-			array_push($this->classStack, $node);
-		}
-		return null;
-	}
-
 	/**
 	 * leaveNode
 	 *
 	 * @param Node $node Instance of Node
 	 *
-	 * @return array|null
+	 * @return int|null|array
 	 */
 	public function leaveNode(Node $node) {
 		if ($node instanceof Class_ || $node instanceof Trait_ || $node instanceof Enum_) {
-			array_pop($this->classStack);
-		} else if ($node instanceof Node\Stmt\TraitUse) {
-
-			$class = end($this->classStack);
-			assert($class);
-			$traits = $this->importer->resolveTraits($node, $class);
-			return $traits;
+			$node->stmts = $this->importer->processClassLike($node);
 		}
 		return null;
 	}

--- a/src/Output/XUnitOutput.php
+++ b/src/Output/XUnitOutput.php
@@ -203,7 +203,7 @@ class XUnitOutput implements OutputInterface {
 		if (is_array($haystack)) {
 			return $this->fileExistsInArray($fileName, $haystack);
 		} else {
-			return Glob::match("/" . $fileName, "/" . $haystack);
+			return self::globCache($fileName, $haystack);
 		}
 	}
 
@@ -213,9 +213,19 @@ class XUnitOutput implements OutputInterface {
 	 *
 	 * @return bool
 	 */
+
+	private static function globCache(string $fileName, string $pattern):bool {
+		static $cacheFile = null;
+		static $matches = [];
+		if ($cacheFile == $fileName && isset($matches[$pattern])) {
+			return $matches[$pattern];
+		}
+		return $matches[$pattern] = Glob::match("/" . $fileName, "/" . $pattern);
+	}
+
 	private function fileExistsInArray($fileName, array $entryArray) : bool {
 		foreach ($entryArray as $entryItem) {
-			if (Glob::match("/" . $fileName, "/" . $entryItem)) {
+			if (self::globCache($fileName, $entryItem)) {
 				return true;
 			}
 		}

--- a/src/SymbolTable/SymbolTable.php
+++ b/src/SymbolTable/SymbolTable.php
@@ -314,7 +314,7 @@ abstract class SymbolTable {
 	 */
 	public function removeBasePath(string $fileName):string {
 		if ($this->basePath!=="" && strpos($fileName, $this->basePath) === 0) {
-			return substr($fileName, strlen($this->basePath)+1);
+			return substr($fileName, strlen($this->basePath));
 		} else {
 			return $fileName;
 		}

--- a/src/TraitImporter.php
+++ b/src/TraitImporter.php
@@ -35,27 +35,71 @@ class TraitImporter {
 	}
 
 	/**
+	 * @param mixed $fileName
+	 * @param int $line
+	 * @param NodeVisitors\Interface_|string|Class_|NodeVisitors\Trait_ $trait
+	 * @param array $properties
+	 * @param array $methods
+	 * @param string $traitName
+	 * @return array
+	 */
+	private function attachTraitLineNumbers(mixed $fileName, int $line, array $stmts, string $traitName) : array {
+		$properties = $methods = $constants = [];
+		$apply = function (Node $node) use ($fileName, $line) {
+			$node->setAttribute('importedFromTrait', $fileName);
+			$node->setAttribute('importedOnLine', $line);
+		};
+
+		$list = array_filter($stmts, function($stmt) {
+			return $stmt instanceof Node\Stmt\Property || $stmt instanceof Node\Stmt\ClassMethod || $stmt instanceof Node\Stmt\ClassConst;
+		});
+		ForEachNode::run($list, $apply);
+
+		foreach ($list as $stmt) {
+			if ($stmt instanceof Node\Stmt\Property) {
+				$props = clone $stmt;
+				$properties[] = $props;
+			} elseif ($stmt instanceof Node\Stmt\ClassMethod) {
+				$method = clone $stmt;
+				$methods[strval($stmt->name)][$traitName] = $method;
+			} elseif ($stmt instanceof Node\Stmt\ClassConst) {
+				$const = clone $stmt;
+				$constants[] = $const;
+			}
+		}
+		return array($properties, $methods, $constants);
+	}
+
+	/**
 	 * resolveAdaptations
 	 *
 	 * @param TraitUseAdaptation[] $adaptations Array of Instances of TraitUseAdaptation
 	 * @param array                $methods     The list of methods
 	 *
-	 * @return void
+	 * @return array
 	 */
-	private function resolveAdaptations(array $adaptations, array &$methods) {
+	private function resolveAdaptations(array $adaptations, array $methods) {
 		foreach ($adaptations as $adaptation) {
+			$adaptationMethodStr = strval($adaptation->method);
 			if ($adaptation instanceof Node\Stmt\TraitUseAdaptation\Alias) {
-				$adaptationMethodStr = strval($adaptation->method);
+
 				// Alias adaptation renames the alias
 				if (!array_key_exists($adaptationMethodStr, $methods)) {
+					echo "Attempt to rename a method  $adaptationMethodStr() that hasn't been imported";
 					continue;
 				}
 
 				/** @var Node\Stmt\ClassMethod $method */
 				if (strval($adaptation->trait) == "") {
+					if (count($methods[$adaptationMethodStr]) > 1) {
+						echo "Attempt to rename a method $adaptationMethodStr() without a trait name when importing from multiple implementations";
+						continue;
+					}
 					$method = end($methods[$adaptationMethodStr]);
+					$traitName = key($methods[$adaptationMethodStr]);
 				} else {
 					$method = $methods[$adaptationMethodStr][strval($adaptation->trait)];
+					$traitName = strval($adaptation->trait);
 				}
 
 				if ($adaptation->newModifier != null) {
@@ -66,17 +110,67 @@ class TraitImporter {
 					$method->name = $adaptation->newName;
 
 					// Unset it from the old name.
-					unset($methods[$adaptationMethodStr][strval($adaptation->trait)]);
+					unset($methods[$adaptationMethodStr][$traitName]);
 					// Add it with the new name.
-					$methods[strval($adaptation->newName)][strval($adaptation->trait)] = $method;
+					$methods[strval($adaptation->newName)][$traitName] = $method;
 				}
 			} else if ($adaptation instanceof Node\Stmt\TraitUseAdaptation\Precedence) {
 				// Instance of adaptation ignores the method from a list of traits.
 				foreach ($adaptation->insteadof as $name) {
-					unset($methods[strval($adaptation->method)][$name]);
+					if (!isset($methods[$adaptationMethodStr][$name])) {
+						echo "Attempt to use precedence for a method $adaptationMethodStr() that hasn't been imported";
+						continue;
+					}
+					unset($methods[$adaptationMethodStr][$name]);
 				}
 			}
 		}
+
+		return $methods;
+	}
+
+	private static function getConstant(ClassLike $class, string $name) {
+		foreach($class->stmts as $stmt) {
+			if ($stmt instanceof Node\Stmt\Const_) {
+				foreach($stmt->consts as $const) {
+					if ($const->name->name == $name) {
+						return [$stmt, $const];
+					}
+				}
+			}
+		}
+		return null;
+	}
+
+	private function constantsAreCompatible(Node\Stmt\ClassConst $parent, Node\Const_ $parentConst, Node\Stmt\ClassConst $child, Node\Const_ $childConst) : bool {
+		if ($parent->flags != $child->flags) {
+			return false;
+		}
+
+		if (!TypeComparer::literalValuesAreEqual($parentConst->value, $childConst->value)) {
+			return false;
+		}
+
+
+		return true;
+	}
+
+	private function importConstants(ClassLike $class, array $constants, array $outputStatements) {
+		/** @var Node\Stmt\ClassConst $constant */
+		foreach($constants as $constant) {
+			foreach($constant->consts as $const) {
+				$existing = self::getConstant($class, $const->name);
+				if (!$existing) {
+					$outputStatements[] = $constant;
+				} else {
+					[$existingStmt, $existingConst] = $existing;
+					if (!$this->constantsAreCompatible($existingStmt, $existingConst, $constant, $const)) {
+						echo "Constant {$const->name} is incompatible with existing constant\n";
+					}
+				}
+			}
+		}
+		return $outputStatements;
 	}
 
 	/**
@@ -87,19 +181,97 @@ class TraitImporter {
 	 *
 	 * @return array
 	 */
-	private function importMethods(ClassLike $class, array $methods) {
-		$stmts = [];
+	private function importMethods(ClassLike $class, array $methods, array $outputStatements) {
 		foreach ($methods as $methodName => $methodArr) {
 			if (count($methodArr) > 1) {
 				echo "[{$class->name}] Too many implementations for $methodName\n";
 			}
 			foreach ($methodArr as $traitName => $method) {
 				if (!$class->getMethod($method->name)) {
-					$stmts[] = $method;
+					$outputStatements[] = $method;
 				}
 			}
 		}
-		return $stmts;
+		return $outputStatements;
+	}
+
+	static function findPropProp(Node\Stmt\Property $prop, $name):?Node\Stmt\PropertyProperty {
+		foreach($prop->props as $propProp) {
+			if ($propProp->name->name == $name) {
+				return $propProp;
+			}
+		}
+		return null;
+	}
+
+	private static function typesAreIdentical($type1, $type2) {
+		$type1 = TypeComparer::normalizeType($type1);
+		$type2 = TypeComparer::normalizeType($type2);
+		return TypeComparer::typeToString($type1) == TypeComparer::typeToString($type2);
+	}
+
+	private function propsAreCompatible(
+		Node\Stmt\Property $parent,
+		Node\Stmt\PropertyProperty $parentProp,
+		Node\Stmt\Property $child,
+		Node\Stmt\PropertyProperty $childProp
+	) : bool {
+		if ($parent->flags != $child->flags) {
+			return false;
+		}
+
+		if (!self::typesAreIdentical($parent->type, $child->type)) {
+			return false;
+		}
+
+		if (!TypeComparer::literalValuesAreEqual($childProp->default, $parentProp->default)) {
+			return false;
+		}
+		return true;
+	}
+
+	private function importProperties(ClassLike $class, array $properties, array $outputStatements) {
+		foreach ($properties as $property) {
+			foreach($property->props as $propertyProperty) {
+				$existing1 = false;
+				foreach($properties as $property2) {
+					foreach ($property2->props as $propertyProperty2) {
+						// If they're the same name, but different instances.
+						if ($propertyProperty->name->name == $propertyProperty2->name->name && $propertyProperty !== $propertyProperty2) {
+							$existing1 = true;
+							if (!$this->propsAreCompatible($property, $propertyProperty, $property2, $propertyProperty2)) {
+								echo "Incompatible property {$propertyProperty->name->name} in two traits being imported into " . ($class->name ?? 'anoynmous class') . "\n";
+							}
+						}
+					}
+				}
+				if (!$existing1) {
+					$existing = $class->getProperty($propertyProperty->name);
+					if (!$existing) {
+						$outputStatements[] = new Node\Stmt\Property($property->flags, [$propertyProperty], $property->getAttributes(), $property->type, $property->attrGroups);
+					} else {
+						$existingPropProp = static::findPropProp($existing, $propertyProperty->name->name);
+						if (!$this->propsAreCompatible($existing, $existingPropProp, $property, $propertyProperty)) {
+							echo "Property {$propertyProperty->name->name} is incompatible with existing property in " . ($class->name ?? "anonymous class") . "\n";
+						}
+					}
+				}
+			}
+		}
+		return $outputStatements;
+	}
+
+	function merge($methods, $newMethods) {
+		foreach($newMethods as $methodName=>$methodArr) {
+			foreach($methodArr as $traitName=>$method) {
+				if (!isset($methods[$methodName])) {
+					$methods[$methodName] = [$traitName=>$method];
+				} else {
+					$methods[$methodName][$traitName] = $method;
+				}
+			}
+		}
+		return $methods;
 	}
 
 	/**
@@ -115,71 +287,107 @@ class TraitImporter {
 	 * @throws UnknownTraitException
 	 */
 	private function indexTrait(TraitUse $use) {
-		$methods = [];
-		$properties = [];
+		$properties = $methods = $constants = [];
+		$newStmts = [];
+		$line = $use->getLine();
 		foreach ($use->traits as $useTrait) {
 			$traitName = strval($useTrait);
 			$trait = $this->index->getTrait($traitName);
-			$line = $use->getLine();
-
-			if ($trait) {
-				$imports = [];
-				// Recurse down into any use statements inside of the trait.
-				foreach ($trait->stmts as $index => $stmt) {
-					if ($stmt instanceof TraitUse) {
-						$imports[] = $stmt;
-						unset($trait->stmts[$index]);
-					}
-				}
-				foreach ($imports as $stmt) {
-					$newStatements = $this->resolveTraits($stmt, $trait);
-					if ($newStatements) {
-						$trait->stmts = array_merge($trait->stmts, $newStatements);
-					}
-				}
-				$trait->stmts = array_values($trait->stmts);
-			}
+			$fileName = $this->index->getTraitFile($traitName);
 
 			if (!$trait) {
 				throw new \BambooHR\Guardrail\Exceptions\UnknownTraitException($traitName, $use->getLine());
 			}
-			$fileName = $this->index->getTraitFile($traitName);
-			$apply = function(Node $node) use ($fileName, $line) {
-				$node->setAttribute('importedFromTrait', $fileName);
-				$node->setAttribute('importedOnLine', $line);
-			};
-			foreach ($trait->stmts as $stmt) {
-				if ($stmt instanceof Node\Stmt\Property) {
-					$props = unserialize( serialize( $stmt ) );
-					ForEachNode::run([$props], $apply);
-					$properties[] = $props;
-				} else if ($stmt instanceof Node\Stmt\ClassMethod) {
-					// Make a deep copy of the node
-					$method = unserialize( serialize( $stmt ) );
-					ForEachNode::run([$method], $apply);
-					$methods[strval($stmt->name)][$traitName] = $method;
+
+			// Recurse down into any use statements inside of the trait.
+			$newStmts = $this->processClassLike($trait);
+			[$newProperties, $newMethods, $newConstants] = $this->attachTraitLineNumbers($fileName, $line, $newStmts, $traitName);
+			$properties=array_merge($properties, $newProperties);
+
+			$methods = $this->merge($methods, $newMethods);
+			$constants = array_merge($constants, $newConstants);
+		}
+		return [$methods, $properties, $constants];
+	}
+
+	private function filterAbstractMethodsWithConcreteVersions($methods):array {
+		foreach ($methods as $methodName => $methodArr) {
+			if (count($methodArr) > 1) {
+				$abstractCount = array_reduce($methodArr, fn($sum,$method) => $sum + ($method->isAbstract() ? 1 : 0), 0);
+				$concreteCount = count($methodArr) - $abstractCount;
+				if ($abstractCount > 0 && $concreteCount > 0) {
+					// If there are both concrete and abstract methods, then discard abstract methods.
+					// (We can't actually paste both into a single class.)
+					$methods[$methodName] = array_filter($methodArr, function($method) { return !$method->isAbstract(); });
 				}
 			}
 		}
-		return [$methods, $properties];
+		return $methods;
 	}
 
-	/**
-	 * resolveTraits
-	 *
-	 * Note: we don't directly recurse down into traits here to resolve their traits.  Instead, we allow that to happen
-	 * indirectly when we call $this->index->getTrait().
-	 *
-	 * @param TraitUse  $use   Instance of TraitUse
-	 * @param ClassLike $class Instance of ClassLike
-	 *
-	 * @return array
-	 *
-	 * @throws UnknownTraitException
-	 */
-	public function resolveTraits(TraitUse $use, ClassLike $class) {
-		[$methods, $properties] = $this->indexTrait($use);
-		$this->resolveAdaptations($use->adaptations, $methods );
-		return array_merge( array_values($properties), $this->importMethods($class, $methods));
+	public function checkAbstractMethodCompatibility(array $methods):void {
+		foreach ($methods as $methodName => $methodArr) {
+			$first = reset($methodArr);
+			$trait1 = key($methodArr);
+			if (count($methodArr) > 1) {
+				/** @var Node\Stmt\ClassMethod $first */
+
+				foreach(array_slice($methodArr,1) as $trait2 => $other) {
+					/** @var Node\Stmt\ClassMethod $other */
+					if ($first->returnsByRef() != $other->returnsByRef()) {
+						echo "Method $methodName returns by reference in one implementation but not the other ($trait1 vs $trait2)\n";
+					}
+					if ($first->isStatic() != $other->isStatic()) {
+						echo "Method $methodName is static in one implementation but not the other ($trait1 vs $trait2)\n";
+					}
+					if ($first->isFinal() != $other->isFinal()) {
+						echo "Method $methodName is final in one implementation but not the other ($trait1 vs $trait2)\n";
+					}
+					if ($first->isPublic() != $other->isPublic()) {
+						echo "Method $methodName is public in one implementation but not the other ($trait1 vs $trait2)\n";
+					}
+					if ($first->isProtected() != $other->isProtected()) {
+						echo "Method $methodName is protected in one implementation but not the other ($trait1 vs $trait2)\n";
+					}
+					if ($first->isPrivate() != $other->isPrivate()) {
+						echo "Method $methodName is private in one implementation but not the other ($trait1 vs $trait2)\n";
+					}
+				}
+			}
+		}
+	}
+
+	public function processClassLike(ClassLike $class):array {
+		$additions = [];
+		$properties = $methods = $constants = [];
+
+		// First, index all methods
+		foreach($class->stmts as $stmt) {
+			if ($stmt instanceof Node\Stmt\TraitUse) {
+				[$newMethods, $newProperties, $newConstants] = $this->indexTrait($stmt);
+				$properties = array_merge($properties, $newProperties);
+				$methods = $this->merge($methods, $newMethods);
+				$constants = array_merge($constants, $newConstants);
+			}
+		}
+		// Second, having seen all uses clauses for the class, we can now import the methods and properties.
+		// Also, while we're at it, make a copy of the all the class statements that aren't "use" statements.
+		foreach($class->stmts as $stmt) {
+			if ($stmt instanceof Node\Stmt\TraitUse) {
+				$methods = $this->resolveAdaptations($stmt->adaptations, $methods);
+			} else {
+				$additions[] = $stmt;
+			}
+		}
+
+
+		$this->checkAbstractMethodCompatibility($methods);
+		$methods = $this->filterAbstractMethodsWithConcreteVersions($methods);
+
+		// Finally, import all trait methods, properties, and constants on the end of the $additions list.
+		$additions = $this->importMethods($class, $methods, $additions);
+		$additions = $this->importProperties($class, $properties, $additions);
+		$additions = $this->importConstants($class, $constants, $additions);
+		return $additions;
 	}
 }

--- a/src/TypeComparer.php
+++ b/src/TypeComparer.php
@@ -64,6 +64,33 @@ class TypeComparer
 		return $type;
 	}
 
+	public static function literalValuesAreEqual(?Node\Expr $a, ?Node\Expr $b):bool {
+		if ($a===null && $b===null) {
+			return true;
+		}
+		if ($a instanceof Node\Scalar && $b instanceof Node\Scalar) {
+			return $a->value == $b->value;
+		}
+		if ($a instanceof Node\Expr\Array_ && $b instanceof Node\Expr\Array_) {
+			if (count($a->items) != count($b->items)) {
+				return false;
+			}
+			foreach($a->items as $index => $item) {
+				if (!isset($b->items[$index])) {
+					return false;
+				}
+				if (!static::literalValuesAreEqual($item->key, $b->items[$index]->value)) {
+					return false;
+				}
+				if (!static::literalValuesAreEqual($item->value, $b->items[$index]->value)) {
+					return false;
+				}
+			}
+			return true;
+		}
+		return false;
+	}
+
 	public static function normalizeType(ComplexType|Identifier|Name|null $type):ComplexType|Identifier|Name|null {
 		if ($type instanceof Node\NullableType) {
 			$type = new UnionType([self::identifierFromName("null"), $type->type]);


### PR DESCRIPTION
- Fixes bug with old version where duplicate traits and methods could be inserted into a class.
- Won't import identical abstract methods from a trait, but will let you declare them.
- Throw an error when importing the same method from multiple traits (use aliasing and insteadof to avoid).
- Duplicate properties must be identical type, visibility, and default literal value in order to be imported from a trait.
- Duplicate constants must be identical type, visibility, and default literal value in order to be import from a trait.
- All classes and enums checked for duplicate method names.
- 
- Todo: index phase silently discards errors and tries to continue, but analysis phase emits errors.