### PR TITLE
Enumeration fixes, including new checks 

### DIFF
--- a/src/Checks/ErrorConstants.php
+++ b/src/Checks/ErrorConstants.php
@@ -81,6 +81,8 @@ class ErrorConstants {
 	const TYPE_VARIABLE_FUNCTION_NAME = 'Standard.VariableFunctionCall';
 	const TYPE_VARIABLE_VARIABLE = 'Standard.VariableVariable';
 	const TYPE_COUNTABLE_EMPTINESS_CHECK = 'Standard.Countable.Emptiness';
+	const TYPE_ENUM_RESERVED_METHOD = 'Standard.Enum.ReservedMethod';
+
 
 
 	/**

--- a/src/EnumCodeAugmenter.php
+++ b/src/EnumCodeAugmenter.php
@@ -2,28 +2,56 @@
 
 namespace BambooHR\Guardrail;
 
+use BambooHR\Guardrail\Checks\ErrorConstants;
+use BambooHR\Guardrail\Output\OutputInterface;
 use PhpParser\Node;
 use PhpParser\Builder\Property;
 use PhpParser\Builder\Param;
 
+
+/**
+ * Class EnumCodeAugmenter
+ *
+ * Simple enum classes are expected to have a name property, a cases() method, and implement the UnitEnum interface.
+ * Backed enum classes are expected to have a name and value property, a cases(), from(), and tryFrom() method, and
+ * implement the BackedEnum interface.
+ *
+ * This class adds these properties and methods to the enum class so that future checks can be made against them.
+ *
+ * @package BambooHR\Guardrail
+ *
+ */
 class EnumCodeAugmenter {
-	static public function addEnumPropsAndMethods(Node\Stmt\Enum_ $enum) {
+	static public function addEnumPropsAndMethods(Node\Stmt\Enum_ $enum, string $fileName, ?OutputInterface $output=null) {
 		$isBacked = !is_null($enum->scalarType);
 		$property = new Property("name");
 		$property->setType(new Node\Identifier("string"));
 		$property->makeReadonly();
-		$enum->stmts[]= $property->getNode();
+		$enum->stmts[] = $property->getNode();
+
+		if ($enum->getMethod("cases")) {
+			$output?->emitError(self::class, $fileName, $enum->getLine(), ErrorConstants::TYPE_ENUM_RESERVED_METHOD, "Enum method 'cases' is reserved");
+		}
+		$enum->stmts[] = new Node\Stmt\ClassMethod("cases", ["returnType" => "array", "flags" => Node\Stmt\Class_::MODIFIER_STATIC | Node\Stmt\Class_::MODIFIER_PUBLIC]);
+
+
 		if ($isBacked) {
-			$enum->stmts[] = new Node\Stmt\ClassMethod("values",["returnType"=>"array"]);
 			$property = new Property("value");
 			$property->makeReadonly();
-			$property->setType( $enum->scalarType );
-			$enum->stmts[]=$property->getNode();
+			$property->setType($enum->scalarType);
+			$enum->stmts[] = $property->getNode();
 
 			$enumName = $enum->namespacedName->toString();
 			$param = (new Param("fromValue"))->setType($enum->scalarType);
-			$enum->stmts[]=new Node\Stmt\ClassMethod("tryFrom",["returnType" => $enumName, "flags"=>Node\Stmt\Class_::MODIFIER_STATIC, 'params'=>[$param->getNode()]]);
-			$enum->stmts[]=new Node\Stmt\ClassMethod("from", ["returnType" => $enumName, "flags"=>Node\Stmt\Class_::MODIFIER_STATIC, 'params'=>[$param->getNode()]]);
+			if ($enum->getMethod("tryFrom") || $enum->getMethod("from")) {
+				$output?->emitError(self::class, $fileName, $enum->getLine(), ErrorConstants::TYPE_ENUM_RESERVED_METHOD, "Enum method 'from' or 'tryFrom' is reserved");
+			}
+			$enum->stmts[] = new Node\Stmt\ClassMethod("tryFrom", ["returnType" => $enumName, "flags" => Node\Stmt\Class_::MODIFIER_STATIC, 'params' => [$param->getNode()]]);
+			$enum->stmts[] = new Node\Stmt\ClassMethod("from", ["returnType" => $enumName, "flags" => Node\Stmt\Class_::MODIFIER_STATIC, 'params' => [$param->getNode()]]);
+		}
+		$implements = ($isBacked ? "BackedEnum" : "UnitEnum");
+		if (!in_array($implements, $enum->implements)) {
+			$enum->implements[] = new Node\Name($implements);
 		}
 	}
 }


### PR DESCRIPTION
- Stop adding a values() method it is incorrect, but do add a cases() static method.
- Stub out error handlers for enum expansion (detect reserved method names).
- Automatically mark UnitEnum and BackedEnum as implemented by the enum as appropriate.