### PR TITLE
[SPN-1703] Make Guardrail not fail if parameter type is not specified for openapi attributes

### DIFF
--- a/src/Checks/OpenApiAttributeDocumentationCheck.php
+++ b/src/Checks/OpenApiAttributeDocumentationCheck.php
@@ -55,7 +55,7 @@ class OpenApiAttributeDocumentationCheck extends BaseCheck {
 							$this->emitErrorOnLine(
 								$fileName,
 								$node->getLine(),
-								ErrorConstants::TYPE_OPEN_API_ATTRIBUTE_DOCUMENTATION_CHECK,
+								ErrorConstants::TYPE_OPEN_API_ATTRIBUTE_MISSING_REQUIRED_EXTENSION_PROPERTY,
 								"OpenAPI Attribute must have a description. Method: {$node->name->name}"
 							);
 						}
@@ -121,11 +121,11 @@ class OpenApiAttributeDocumentationCheck extends BaseCheck {
 	}
 
 	private function hasDescription($arg): bool {
-		return $arg->name->name === self::DESCRIPTION_KEY && !empty($arg->value->value);
+		return $arg?->name?->name === self::DESCRIPTION_KEY && !empty($arg->value->value);
 	}
 
 	private function hasTeamName($arg): bool {
-		if ($arg->name->name === self::X_KEY && $arg->value instanceof Node\Expr\Array_) {
+		if ($arg?->name?->name === self::X_KEY && $arg->value instanceof Node\Expr\Array_) {
 			foreach ($arg->value->items as $item) {
 				if ($item->key->value === self::TEAM_NAME_KEY && !empty($item->value->value)) {
 					return true;

--- a/tests/units/Checks/TestData/TestOpenApiAttributeDocumentationCheck.4.inc
+++ b/tests/units/Checks/TestData/TestOpenApiAttributeDocumentationCheck.4.inc
@@ -32,4 +32,38 @@ class MyController extends BaseController {
 	public function withAllProperties() {
 		return false;
 	}
+
+	// We don't support non type hinted arguments. This should emit one error for description
+	#[\Onsen\SecurityAudit\Sensitivity\Low]
+	#[OA\Get('path',
+		'operationId',
+		'description',
+		'summary',
+		[['oauth' => []]],
+		x: ['team-name' => 'my-team'],
+	)]
+	public function testWithoutDescriptionParamHint() {
+		return false;
+	}
+
+	// We don't support non type hinted arguments. This should emit two errors for description and team name
+	#[\Onsen\SecurityAudit\Sensitivity\Low]
+	#[OA\Get('path',
+		'operationId',
+		'description',
+		'summary',
+		[['oauth' => []]],
+		'servers',
+		'requestBody',
+		'tags',
+		'parameters',
+		'responses',
+		'callbacks',
+		'externalDocs',
+		'deprecated',
+		['team-name' => 'my-team'],
+	)]
+	public function testWithoutParamHints() {
+		return false;
+	}
 }

--- a/tests/units/Checks/TestOpenApiAttributeDocumentationCheck.php
+++ b/tests/units/Checks/TestOpenApiAttributeDocumentationCheck.php
@@ -34,13 +34,6 @@ class TestOpenApiAttributeDocumentationCheck extends TestSuiteSetup {
 	 * @return void
 	 */
 	public function testWithAndWithoutRequiredProperties() {
-		$this->assertEquals(2, $this->runAnalyzerOnFile('.4.inc', ErrorConstants::TYPE_OPEN_API_ATTRIBUTE_DOCUMENTATION_CHECK), "");
-	}
-
-	/**
-	 * @return void
-	 */
-	public function testWithAndWithoutRequiredTeamName() {
-		$this->assertEquals(3, $this->runAnalyzerOnFile('.4.inc', ErrorConstants::TYPE_OPEN_API_ATTRIBUTE_MISSING_REQUIRED_EXTENSION_PROPERTY), "");
+		$this->assertEquals(8, $this->runAnalyzerOnFile('.4.inc', ErrorConstants::TYPE_OPEN_API_ATTRIBUTE_MISSING_REQUIRED_EXTENSION_PROPERTY), "");
 	}
 }


### PR DESCRIPTION
* To make guardrail not fail if the openapi attribute type hint is not provided
* To emit the correct error if the description is not present