### PR TITLE
feat(check): implements GlobalFunctionCheck

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_STORE
 vendor
 composer.lock
 .vagrant

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Guardrail classifies checks by name.  Here is the standard list of errors.  Note
 | Standard.Inheritance.Unimplemented  | Class implementing an interface fails to implement on of it's methods.                                       |
 | Standard.Function.InsideFunction    | Declaring a function inside of another function.  (Closures/lambdas are still allowed.)                      |
 | Standard.Global.Expression          | Referencing $GLOBALS\[ $expr ]                                                                               |
+| Standard.Global.Function            | Function defined at the global level. Functions should be placed in namespaces, classes, or conditional blocks. |
 | Standard.Global.String              | Referencing a global with either global $var or $GLOBALS\['var']                                             |
 | Standard.Goto                       | Any instance of a "goto" statement                                                                           |
 | Standard.Override.Base              | Attempt to use a #\[Override] on method in a base class                                                      |

--- a/src/Checks/ErrorConstants.php
+++ b/src/Checks/ErrorConstants.php
@@ -21,6 +21,7 @@ class ErrorConstants {
 	const TYPE_PSR4 = "Standard.Psr4";
 	const TYPE_DEPRECATED_INTERNAL = 'Standard.Deprecated.Internal';
 	const TYPE_DEPRECATED_USER = 'Standard.Deprecated.User';
+	const TYPE_GLOBAL_FUNCTION = 'Standard.Global.Function';
 	const TYPE_DOC_BLOCK_MISMATCH = 'Standard.DocBlock.Mismatch';
 	const TYPE_DOC_BLOCK_PARAM = 'Standard.DocBlock.Param';
 	const TYPE_DOC_BLOCK_RETURN = 'Standard.DocBlock.Return';

--- a/src/Checks/GlobalFunctionCheck.php
+++ b/src/Checks/GlobalFunctionCheck.php
@@ -1,0 +1,106 @@
+<?php namespace BambooHR\Guardrail\Checks;
+
+/**
+ * Guardrail.  Copyright (c) 2016-2024, BambooHR.
+ * Apache 2.0 License
+ */
+
+use PhpParser\Node\Stmt\Function_;
+use BambooHR\Guardrail\Output\OutputInterface;
+use BambooHR\Guardrail\Scope;
+use BambooHR\Guardrail\SymbolTable\SymbolTable;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassLike;
+
+/**
+ * Class GlobalFunctionCheck
+ *
+ * Checks that functions are not defined at the global level.
+ * Functions should be placed in namespaces, classes, or conditional blocks.
+ *
+ * @package BambooHR\Guardrail\Checks
+ */
+class GlobalFunctionCheck extends BaseCheck {
+
+    /**
+     * GlobalFunctionCheck constructor.
+     *
+     * @param SymbolTable     $symbolTable Instance of the SymbolTable
+     * @param OutputInterface $output      Instance of the OutputInterface
+     */
+    public function __construct(SymbolTable $symbolTable, OutputInterface $output) {
+        parent::__construct($symbolTable, $output);
+    }
+
+    /**
+     * getCheckNodeTypes
+     *
+     * @return array
+     */
+    public function getCheckNodeTypes() {
+        return [Function_::class];
+    }
+
+    /**
+     * Run the check on a function node
+     *
+     * @param string $fileName The file being analyzed
+     * @param Function_ $node The function node
+     * @param ClassLike|null $inside The class containing the function (null if global)
+     * @param Scope|null $scope The current scope
+     * @return void
+     */
+
+    public function run($fileName, Node $node, ClassLike $inside = null, Scope $scope = null) {
+        if (!$node instanceof Function_) {
+            return;
+        }
+
+        // Skip functions inside classes (methods)
+        if ($inside !== null) {
+            return;
+        }
+
+        // Skip functions inside namespaces (not in global namespace)
+        // Functions in namespaces have a namespace prefix in their name
+        if (strpos($node->namespacedName->toString(), '\\') !== false) {
+            return;
+        }
+
+        // Skip functions inside conditional blocks (like if/else)
+        if ($scope && $this->isInsideConditionalDeclaration($node, $scope)) {
+            return;
+        }
+
+        // If we get here, the function is in the global namespace and not inside a conditional block
+        // This is not allowed
+        $name = $node->namespacedName->toString();
+        $this->emitError(
+            $fileName,
+            $node,
+            ErrorConstants::TYPE_GLOBAL_FUNCTION,
+            "Function $name() is defined at the global level. Functions should be placed in namespaces, classes, or conditional blocks"
+        );
+    }
+
+    /**
+     * Check if a function is declared inside a conditional block (like if/else)
+     *
+     * @param Function_ $node The function node
+     * @param Scope $scope The current scope
+     * @return bool True if inside a conditional declaration
+     */
+    private function isInsideConditionalDeclaration(Function_ $node, Scope $scope) {
+        // Get parent nodes from the scope
+        $parents = $scope->getParentNodes();
+
+        foreach ($parents as $parent) {
+            if ($parent instanceof Node\Stmt\If_ ||
+                $parent instanceof Node\Stmt\ElseIf_ ||
+                $parent instanceof Node\Stmt\Else_) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/NodeVisitors/StaticAnalyzer.php
+++ b/src/NodeVisitors/StaticAnalyzer.php
@@ -17,6 +17,7 @@ use BambooHR\Guardrail\Checks\ConstructorCheck;
 use BambooHR\Guardrail\Checks\CountableEmptinessCheck;
 use BambooHR\Guardrail\Checks\CyclomaticComplexityCheck;
 use BambooHR\Guardrail\Checks\DefinedConstantCheck;
+use BambooHR\Guardrail\Checks\GlobalFunctionCheck;
 use BambooHR\Guardrail\Checks\DocBlockTypesCheck;
 use BambooHR\Guardrail\Checks\EnumCheck;
 use BambooHR\Guardrail\Checks\FunctionCallCheck;
@@ -158,6 +159,7 @@ class StaticAnalyzer extends NodeVisitorAbstract
 			new ClassConstCheck($this->index, $output),
 			new ThrowsCheck($this->index, $output),
 			new CountableEmptinessCheck($this->index, $output),
+			new GlobalFunctionCheck($this->index, $output),
 			new DependenciesOnVendorCheck($this->index, $output, $metricOutput),
 			new OpenApiAttributeDocumentationCheck($this->index, $output, $metricOutput),
 			new ServiceMethodDocumentationCheck($this->index, $output, $metricOutput),

--- a/tests/TestSuiteSetup.php
+++ b/tests/TestSuiteSetup.php
@@ -119,6 +119,7 @@ abstract class TestSuiteSetup extends TestCase {
 		$fileName = "test.php";
 		$emit = ErrorConstants::getConstants();
 		unset( $emit[array_search(ErrorConstants::TYPE_AUTOLOAD_ERROR, $emit)] );
+		unset( $emit[array_search(ErrorConstants::TYPE_GLOBAL_FUNCTION, $emit)] );
 		$additionalConfig = array_merge(["basePath" => "/"], $additionalConfig);
 		return $this->analyzeStringToOutput($fileName, $fileData, $emit, $additionalConfig);
 	}

--- a/tests/units/Checks/GlobalFunctionCheckTest.php
+++ b/tests/units/Checks/GlobalFunctionCheckTest.php
@@ -1,0 +1,67 @@
+<?php namespace BambooHR\Guardrail\Tests\Checks;
+
+use BambooHR\Guardrail\Checks\GlobalFunctionCheck;
+use BambooHR\Guardrail\Checks\ErrorConstants;
+use BambooHR\Guardrail\Tests\TestSuiteSetup;
+
+/**
+ * Class GlobalFunctionCheckTest
+ *
+ * Tests for the GlobalFunctionCheck class, which prohibits functions at the global level
+ * while allowing them in namespaces, classes, or conditional blocks.
+ *
+ * @package BambooHR\Guardrail\Tests\Checks
+ */
+class GlobalFunctionCheckTest extends TestSuiteSetup {
+
+    /**
+     * Provides test cases for the GlobalFunctionCheck
+     *
+     * @return array Array of test cases with [description, file, expected error count]
+     */
+    public function functionLocationProvider(): array {
+        return [
+            'global function' => [
+                'Function at the global level should be flagged',
+                '.1.inc',
+                1
+            ],
+            'class method' => [
+                'Method inside a class should be allowed',
+                '.2.inc',
+                0
+            ],
+            'simple conditional function' => [
+                'Function inside a simple conditional block should be allowed',
+                '.3.inc',
+                0
+            ],
+            'namespaced function' => [
+                'Function inside a namespace should be allowed',
+                '.4.inc',
+                0
+            ],
+            'complex conditional function' => [
+                'Function inside a complex conditional block should be allowed',
+                '.5.inc',
+                0
+            ],
+        ];
+    }
+
+    /**
+     * Test function locations
+     *
+     * @dataProvider functionLocationProvider
+     * @param string $description Test case description
+     * @param string $file Test file to analyze
+     * @param int $expectedErrorCount Expected number of errors
+     * @return void
+     * @rapid-unit Checks:GlobalFunctionCheck:Validates function locations
+     */
+    public function testFunctionLocations(string $description, string $file, int $expectedErrorCount) {
+        $this->assertEquals($expectedErrorCount, $this->runAnalyzerOnFile($file, ErrorConstants::TYPE_GLOBAL_FUNCTION), $description);
+    }
+
+
+}

--- a/tests/units/Checks/TestData/GlobalFunctionCheckTest.1.inc
+++ b/tests/units/Checks/TestData/GlobalFunctionCheckTest.1.inc
@@ -1,0 +1,6 @@
+<?php
+
+// This file contains a function at the global level (should trigger an error)
+function test_global_function() {
+    return "Function at the global level";
+}

--- a/tests/units/Checks/TestData/GlobalFunctionCheckTest.2.inc
+++ b/tests/units/Checks/TestData/GlobalFunctionCheckTest.2.inc
@@ -1,0 +1,8 @@
+<?php
+
+// This file contains a function inside a class (should be allowed)
+class TestClass {
+    public function test_class_method() {
+        return "Class method";
+    }
+}

--- a/tests/units/Checks/TestData/GlobalFunctionCheckTest.3.inc
+++ b/tests/units/Checks/TestData/GlobalFunctionCheckTest.3.inc
@@ -1,0 +1,8 @@
+<?php
+
+// This file contains a function inside a conditional block (should be allowed)
+if (true) {
+    function test_conditional_function() {
+        return "Function inside a conditional block";
+    }
+}

--- a/tests/units/Checks/TestData/GlobalFunctionCheckTest.4.inc
+++ b/tests/units/Checks/TestData/GlobalFunctionCheckTest.4.inc
@@ -1,0 +1,14 @@
+<?php
+
+// This file contains functions inside namespaces (should be allowed)
+namespace FirstNamespace {
+    function duplicate_function_name() {
+        return "Function in first namespace";
+    }
+}
+
+namespace SecondNamespace {
+    function duplicate_function_name() {
+        return "Function in second namespace";
+    }
+}

--- a/tests/units/Checks/TestData/GlobalFunctionCheckTest.5.inc
+++ b/tests/units/Checks/TestData/GlobalFunctionCheckTest.5.inc
@@ -1,0 +1,9 @@
+<?php
+
+// This file contains a function inside an if statement with a more complex condition
+// to test the isInsideConditionalDeclaration method specifically
+if ($someVariable === true && !empty($anotherVariable)) {
+    function test_complex_conditional_function() {
+        return "Function inside a complex conditional block";
+    }
+}

--- a/tests/units/Checks/TestTemplates.php
+++ b/tests/units/Checks/TestTemplates.php
@@ -13,16 +13,16 @@ class TestTemplates extends TestSuiteSetup {
 			"ignore-errors" => [
 				"Standard.Autoload.Unsafe", ErrorConstants::TYPE_OPEN_API_ATTRIBUTE_DOCUMENTATION_CHECK,
 				ErrorConstants::TYPE_SERVICE_METHOD_DOCUMENTATION_CHECK,
-			]
+				"Standard.Global.Function"]
 		]));
 	}
 
 
 	function testFunctionTemplate() {
-		$this->assertEquals(0, $this->runAnalyzerOnFile('.2.inc', "Standard.*",["ignore-errors"=>["Standard.Autoload.Unsafe"]]));
+		$this->assertEquals(0, $this->runAnalyzerOnFile('.2.inc', "Standard.*",["ignore-errors"=>["Standard.Autoload.Unsafe", "Standard.Global.Function"]]));
 	}
 
 	function testTemplateParam() {
-		$this->assertEquals(0, $this->runAnalyzerOnFile('.3.inc', "Standard.*",["ignore-errors"=>["Standard.Autoload.Unsafe"]]));
+		$this->assertEquals(0, $this->runAnalyzerOnFile('.3.inc', "Standard.*",["ignore-errors"=>["Standard.Autoload.Unsafe", "Standard.Global.Function"]]));
 	}
 }


### PR DESCRIPTION
Implement a check that prohibits functions at the global level while allowing them in namespaces, classes, and conditional blocks.

- Create GlobalFunctionCheck class to enforce proper function placement
- Add TYPE_GLOBAL_FUNCTION error constant for reporting violations
- Implement detection logic for functions in different contexts
- Allow functions in namespaces, classes, and conditional blocks
- Flag functions defined at the global level
- Create comprehensive tests using data provider pattern
- Include test cases for all supported function locations