### PR TITLE
fix(streaming): When dealing with large files

### DIFF
--- a/src/Filters/UnifiedDiffFilter.php
+++ b/src/Filters/UnifiedDiffFilter.php
@@ -67,7 +67,25 @@ class UnifiedDiffFilter implements FilterInterface {
 	 */
 	function display() {
 		foreach ($this->filter as $fileName => $lineNumbers) {
-			echo "Filter: $fileName: " . implode(",", $lineNumbers) . "\n";
+			echo "Filter: $fileName: ";
+			
+			// Stream output in chunks to avoid memory issues with large files
+			$chunkSize = 100; // Adjust based on your needs
+			$totalLines = count($lineNumbers);
+			
+			for ($i = 0; $i < $totalLines; $i += $chunkSize) {
+				$chunk = array_slice($lineNumbers, $i, $chunkSize);
+				echo implode(",", $chunk);
+				
+				// Flush output buffer to ensure content is sent to output
+				if ($i + $chunkSize < $totalLines) {
+					echo ",";
+					flush();
+				}
+			}
+			
+			echo "\n";
+			flush();
 		}
 	}
 


### PR DESCRIPTION
- When dealing with large files, stream the string output, instead of overloading the implode method. There may be a large memory impact when using implode.