### PR TITLE
Shayman/attribute check

### DIFF
--- a/src/Abstractions/AttributeAbstraction.php
+++ b/src/Abstractions/AttributeAbstraction.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace BambooHR\Guardrail\Abstractions;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Attribute as NodeAttribute;
+
+readonly class AttributeAbstraction implements AttributeInterface
+{
+	public function __construct(
+		private NodeAttribute $attribute
+	) {}
+
+	function getName(): string
+	{
+		return $this->attribute->name;
+	}
+
+	function getArgumentExpressions(): array
+	{
+		// TODO(shayman@bamboohr.com): Double check logic
+		// focusing on argument order
+		return array_map(
+			fn(Arg $arg) => $arg->value,
+			$this->attribute->args
+		);
+	}
+}

--- a/src/Abstractions/AttributeAbstraction.php
+++ b/src/Abstractions/AttributeAbstraction.php
@@ -2,27 +2,20 @@
 
 namespace BambooHR\Guardrail\Abstractions;
 
-use PhpParser\Node\Arg;
 use PhpParser\Node\Attribute as NodeAttribute;
 
-readonly class AttributeAbstraction implements AttributeInterface
-{
-	public function __construct(
-		private NodeAttribute $attribute
-	) {}
-
-	function getName(): string
+readonly class AttributeAbstraction implements AttributeInterface {
+	public function __construct(private NodeAttribute $attr)
 	{
-		return $this->attribute->name->toString();
 	}
 
-	function getArgumentExpressions(): array
+	public function getClassName(): string
 	{
-		// TODO(shayman@bamboohr.com): Double check logic
-		// focusing on argument order
-		return array_map(
-			fn(Arg $arg) => $arg->value,
-			$this->attribute->args
-		);
+		return $this->attr->name->toString();
+	}
+
+	public function getArguments(): array
+	{
+		return $this->attr->args;
 	}
 }

--- a/src/Abstractions/AttributeAbstraction.php
+++ b/src/Abstractions/AttributeAbstraction.php
@@ -13,7 +13,7 @@ readonly class AttributeAbstraction implements AttributeInterface
 
 	function getName(): string
 	{
-		return $this->attribute->name;
+		return $this->attribute->name->toString();
 	}
 
 	function getArgumentExpressions(): array

--- a/src/Abstractions/AttributeInterface.php
+++ b/src/Abstractions/AttributeInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace BambooHR\Guardrail\Abstractions;
+
+use PhpParser\Node\Expr;
+
+/**
+ * This interface represents the application of an attribute.
+ * It is not the attribute class itself, but rather a representation of
+ * how an attribute is applied to a class, method, property, etc.
+ */
+interface AttributeInterface
+{
+	/**
+	 * This method returns the name of the attribute class being applied.
+	 */
+	function getName(): string;
+
+	/**
+	 * This method returns an array of arguments that were passed to the
+	 * attribute's constructor when it was applied.
+	 *
+	 * @return Expr[]
+	 */
+	function getArgumentExpressions(): array;
+}

--- a/src/Abstractions/AttributeInterface.php
+++ b/src/Abstractions/AttributeInterface.php
@@ -2,25 +2,13 @@
 
 namespace BambooHR\Guardrail\Abstractions;
 
-use PhpParser\Node\Expr;
+use PhpParser\Node\Arg;
 
-/**
- * This interface represents the application of an attribute.
- * It is not the attribute class itself, but rather a representation of
- * how an attribute is applied to a class, method, property, etc.
- */
-interface AttributeInterface
-{
-	/**
-	 * This method returns the name of the attribute class being applied.
-	 */
-	function getName(): string;
+interface AttributeInterface {
+	public function getClassName(): string;
 
 	/**
-	 * This method returns an array of arguments that were passed to the
-	 * attribute's constructor when it was applied.
-	 *
-	 * @return Expr[]
+	 * @return Arg[]
 	 */
-	function getArgumentExpressions(): array;
+	public function getArguments(): array;
 }

--- a/src/Abstractions/ClassAbstraction.php
+++ b/src/Abstractions/ClassAbstraction.php
@@ -262,30 +262,16 @@ class ClassAbstraction implements ClassInterface {
 		return $attributes;
 	}
 
-	public function getConstant(string $name): mixed
+	public function getConstantValueExpression(string $name): ?Expr
 	{
-		$classConstStmts = Grabber::filterByType($this->class->stmts, [ClassConst::class]);
-
-		foreach ($classConstStmts as $classConstStmt) {
-			if ($classConstStmt instanceof ClassConst) {
-				foreach ($classConstStmt->consts as $const) {
-					if (strcasecmp($const->name, $name) == 0) {
-						if ($const->value instanceof Scalar) {
-							return $const->value->value;
-						} else if ($const->value instanceof Expr\ConstFetch) {
-							if (strcasecmp($const->value->name, "true") == 0 ||
-								strcasecmp($const->value->name, "false") == 0)
-								return strcasecmp($const->value->name, "true") == 0;
-
-							if (strcasecmp($const->value->name, "NULL") == 0) {
-								return null;
-							}
-						}
-					}
+		foreach ($this->class->getConstants() as $classConsts) {
+			foreach ($classConsts->consts as $const) {
+				if ($const->name == $name) {
+					return $const->value;
 				}
 			}
 		}
 
-		throw new InvalidArgumentException();
+		return null;
 	}
 }

--- a/src/Abstractions/ClassInterface.php
+++ b/src/Abstractions/ClassInterface.php
@@ -1,5 +1,6 @@
 <?php namespace BambooHR\Guardrail\Abstractions;
 
+use InvalidArgumentException;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
@@ -97,4 +98,16 @@ interface ClassInterface {
 	public function isEnum():bool;
 
 	public function isReadOnly():bool;
+
+	/**
+	 * @return AttributeInterface[]
+	 */
+	public function getAttributes(): array;
+
+	// TODO(shayman@bamboohr.com): Review design
+
+	/**
+	 * @throws InvalidArgumentException
+	 */
+	public function getConstant(string $name): mixed;
 }

--- a/src/Abstractions/ClassInterface.php
+++ b/src/Abstractions/ClassInterface.php
@@ -1,6 +1,5 @@
 <?php namespace BambooHR\Guardrail\Abstractions;
 
-use InvalidArgumentException;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
@@ -104,10 +103,5 @@ interface ClassInterface {
 	 */
 	public function getAttributes(): array;
 
-	// TODO(shayman@bamboohr.com): Review design
-
-	/**
-	 * @throws InvalidArgumentException
-	 */
-	public function getConstant(string $name): mixed;
+	public function getConstantValueExpression(string $name): ?Expr;
 }

--- a/src/Abstractions/ReflectedAttribute.php
+++ b/src/Abstractions/ReflectedAttribute.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace BambooHR\Guardrail\Abstractions;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\DNumber;
+use PhpParser\Node\Scalar\LNumber;
+use PhpParser\Node\Scalar\String_;
+use ReflectionAttribute;
+
+readonly class ReflectedAttribute implements AttributeInterface
+{
+	public function __construct(private ReflectionAttribute $reflectionAttribute) {}
+
+	public function getName(): string {
+		return $this->reflectionAttribute->getName();
+	}
+
+	public function getArgumentExpressions(): array {
+		return array_map(
+			fn(mixed $argumentValue) => $this->toExpression($argumentValue),
+			$this->reflectionAttribute->getArguments()
+		);
+	}
+
+	private function toExpression(mixed $argumentValue): ?Expr {
+		return match (gettype($argumentValue)) {
+			"boolean" => new ConstFetch(new Name($argumentValue ? "true" : "false")),
+			"integer" => new LNumber($argumentValue),
+			"double" => new DNumber($argumentValue),
+			"string" => new String_($argumentValue),
+			"array" => new Array_(array_map(
+				fn(mixed $arrayItemValue) => new Expr\ArrayItem($this->toExpression($arrayItemValue)),
+				$argumentValue
+			)),
+			"NULL" => new ConstFetch(new Name("null")),
+			default => throw new \InvalidArgumentException("Unsupported type in attribute argument: " . gettype($argumentValue))
+		};
+	}
+}

--- a/src/Abstractions/ReflectedAttribute.php
+++ b/src/Abstractions/ReflectedAttribute.php
@@ -26,7 +26,7 @@ readonly class ReflectedAttribute implements AttributeInterface
 		);
 	}
 
-	private function toExpression(mixed $argumentValue): ?Expr {
+	private function toExpression(mixed $argumentValue): Expr {
 		return match (gettype($argumentValue)) {
 			"boolean" => new ConstFetch(new Name($argumentValue ? "true" : "false")),
 			"integer" => new LNumber($argumentValue),

--- a/src/Abstractions/ReflectedAttribute.php
+++ b/src/Abstractions/ReflectedAttribute.php
@@ -2,42 +2,26 @@
 
 namespace BambooHR\Guardrail\Abstractions;
 
-use PhpParser\Node\Expr;
-use PhpParser\Node\Expr\Array_;
-use PhpParser\Node\Expr\ConstFetch;
-use PhpParser\Node\Name;
-use PhpParser\Node\Scalar\DNumber;
-use PhpParser\Node\Scalar\LNumber;
-use PhpParser\Node\Scalar\String_;
+use BambooHR\Guardrail\Util;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Identifier;
 use ReflectionAttribute;
 
-readonly class ReflectedAttribute implements AttributeInterface
-{
-	public function __construct(private ReflectionAttribute $reflectionAttribute) {}
+class ReflectedAttribute implements AttributeInterface {
+	public function __construct(private ReflectionAttribute $attribute) {}
 
-	public function getName(): string {
-		return $this->reflectionAttribute->getName();
+	public function getClassName(): string {
+		return $this->attribute->getName();
 	}
 
-	public function getArgumentExpressions(): array {
-		return array_map(
-			fn(mixed $argumentValue) => $this->toExpression($argumentValue),
-			$this->reflectionAttribute->getArguments()
-		);
-	}
-
-	private function toExpression(mixed $argumentValue): Expr {
-		return match (gettype($argumentValue)) {
-			"boolean" => new ConstFetch(new Name($argumentValue ? "true" : "false")),
-			"integer" => new LNumber($argumentValue),
-			"double" => new DNumber($argumentValue),
-			"string" => new String_($argumentValue),
-			"array" => new Array_(array_map(
-				fn(mixed $arrayItemValue) => new Expr\ArrayItem($this->toExpression($arrayItemValue)),
-				$argumentValue
-			)),
-			"NULL" => new ConstFetch(new Name("null")),
-			default => throw new \InvalidArgumentException("Unsupported type in attribute argument: " . gettype($argumentValue))
-		};
+	public function getArguments(): array {
+		$args = [];
+		foreach ($this->attribute->getArguments() as $name => $value) {
+			$args[] = new Arg(
+				value: Util::valueToExpression($value),
+				name: is_string($name) ? new Identifier($name) : null
+			);
+		}
+		return $args;
 	}
 }

--- a/src/Abstractions/ReflectedClass.php
+++ b/src/Abstractions/ReflectedClass.php
@@ -2,12 +2,9 @@
 
 use BambooHR\Guardrail\TypeComparer;
 use BambooHR\Guardrail\Util;
-use PhpParser\Node\Expr;
+use InvalidArgumentException;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
-use PhpParser\Node\Scalar\DNumber;
-use PhpParser\Node\Scalar\LNumber;
-use PhpParser\Node\Scalar\String_;
 
 /**
  * Guardrail.  Copyright (c) 2016-2023, BambooHR.
@@ -197,5 +194,16 @@ class ReflectedClass implements ClassInterface {
 			return $this->refl->isReadOnly();
 		}
 		return false;
+	}
+
+	public function getAttributes(): array {
+		return array_map(
+			fn($attribute) => new ReflectedAttribute($attribute),
+			$this->refl->getAttributes()
+		);
+	}
+
+	public function getConstant(string $name): mixed {
+		return $this->refl->getConstant($name) ?? throw new InvalidArgumentException("Constant '$name' does not exist");
 	}
 }

--- a/src/Abstractions/ReflectedClass.php
+++ b/src/Abstractions/ReflectedClass.php
@@ -204,6 +204,11 @@ class ReflectedClass implements ClassInterface {
 	}
 
 	public function getConstant(string $name): mixed {
-		return $this->refl->getConstant($name) ?? throw new InvalidArgumentException("Constant '$name' does not exist");
+		if ($this->hasConstant($name)) {
+			return $this->refl->getConstant($name);
+		}
+		else {
+			throw new InvalidArgumentException("Constant '$name' does not exist");
+		}
 	}
 }

--- a/src/Abstractions/ReflectedClass.php
+++ b/src/Abstractions/ReflectedClass.php
@@ -2,16 +2,9 @@
 
 use BambooHR\Guardrail\TypeComparer;
 use BambooHR\Guardrail\Util;
-use InvalidArgumentException;
 use PhpParser\Node\Expr;
-use PhpParser\Node\Expr\Array_;
-use PhpParser\Node\Expr\ArrayItem;
-use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
-use PhpParser\Node\Scalar\DNumber;
-use PhpParser\Node\Scalar\LNumber;
-use PhpParser\Node\Scalar\String_;
 
 /**
  * Guardrail.  Copyright (c) 2016-2023, BambooHR.
@@ -211,35 +204,12 @@ class ReflectedClass implements ClassInterface {
 	}
 
 	public function getConstantValueExpression(string $name): ?Expr {
-		$constant = $this->refl->getConstant($name);
 		if ($this->refl->hasConstant($name)) {
 			$constant = $this->refl->getConstant($name);
-			return $this->wrapValueInExpression($constant);
+			return Util::valueToExpression($constant);
 		}
 		else {
 			return null;
 		}
-	}
-
-	private function wrapValueInExpression(mixed $value): ?Expr {
-		return match (gettype($value)) {
-			'boolean' => new ConstFetch(new Name($value ? 'true' : 'false')),
-			'integer' => new LNumber($value),
-			'double'  => new DNumber($value),
-			'string'  => new String_($value),
-			'array'   => $this->wrapArrayInExpression($value),
-			'NULL'    => new ConstFetch(new Name('null')),
-			default   => null, // Handles invalid types like resources or objects
-		};
-	}
-
-	private function wrapArrayInExpression(mixed $values): ?Expr {
-		$items = [];
-		foreach ($values as $key => $value) {
-			$itemValue = $this->wrapValueInExpression($value);
-			$itemKey = is_int($key) ? new LNumber($key) : new String_($key);
-			$items[] = new ArrayItem($itemValue, $itemKey);
-		}
-		return new Array_($items);
 	}
 }

--- a/src/Checks/AttributeCheck.php
+++ b/src/Checks/AttributeCheck.php
@@ -254,7 +254,7 @@ readonly class ConstantExpressionEvaluator {
 				default => $class->toString(),
 			};
 		} else {
-			return $this->evaluate($class->expr, $inside, $scope);
+			return $this->evaluate($class, $inside, $scope);
 		}
 	}
 

--- a/src/Checks/AttributeCheck.php
+++ b/src/Checks/AttributeCheck.php
@@ -2,12 +2,22 @@
 
 namespace BambooHR\Guardrail\Checks;
 
+use BambooHR\Guardrail\Abstractions\AttributeInterface;
+use BambooHR\Guardrail\Abstractions\ClassInterface;
 use BambooHR\Guardrail\Output\OutputInterface;
 use BambooHR\Guardrail\Scope;
 use BambooHR\Guardrail\SymbolTable\SymbolTable;
-use BambooHR\Guardrail\Util;
+use Error;
+use InvalidArgumentException;
+use PhpParser\ConstExprEvaluationException;
+use PhpParser\ConstExprEvaluator;
 use PhpParser\Node;
 use PhpParser\Node\Attribute as NodeAttribute;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Class_;
@@ -23,42 +33,45 @@ use Attribute;
 class AttributeCheck extends BaseCheck
 {
 	private InstantiationCheck $instantiationCheck;
+	private ConstantExpressionEvaluator $constantExpressionEvaluator;
 
-	public function __construct(SymbolTable $symbolTable, OutputInterface $doc) {
+	public function __construct(SymbolTable $symbolTable, OutputInterface $doc)
+	{
 		parent::__construct($symbolTable, $doc);
 
 		$this->instantiationCheck = new InstantiationCheck($symbolTable, $doc);
+		$this->constantExpressionEvaluator = new ConstantExpressionEvaluator($symbolTable);
 	}
 
 	/**
-     * getCheckNodeTypes
-     *
-     * @return string[]
-     */
-    public function getCheckNodeTypes(): array
+	 * getCheckNodeTypes
+	 *
+	 * @return string[]
+	 */
+	public function getCheckNodeTypes(): array
 	{
-        return [
-            Function_::class,
-            Class_::class,
-            ClassConst::class,
-            Property::class,
-            ClassMethod::class,
-            Param::class,
-            Interface_::class,
-            Trait_::class,
-            Enum_::class
-        ];
-    }
+		return [
+			Function_::class,
+			Class_::class,
+			ClassConst::class,
+			Property::class,
+			ClassMethod::class,
+			Param::class,
+			Interface_::class,
+			Trait_::class,
+			Enum_::class
+		];
+	}
 
-    /**
-     * @param string         $fileName The name of the file we are parsing
-     * @param Node           $node     Instance of the Node
-     * @param ClassLike|null $inside   Instance of the ClassLike (the class we are parsing) [optional]
-     * @param Scope|null     $scope    Instance of the Scope (all variables in the current state) [optional]
-     *
-     * @return void
-     */
-    public function run($fileName, Node $node, ?ClassLike $inside = null, ?Scope $scope = null): void
+	/**
+	 * @param string $fileName The name of the file we are parsing
+	 * @param Node $node Instance of the Node
+	 * @param ClassLike|null $inside Instance of the ClassLike (the class we are parsing) [optional]
+	 * @param Scope|null $scope Instance of the Scope (all variables in the current state) [optional]
+	 *
+	 * @return void
+	 */
+	public function run($fileName, Node $node, ?ClassLike $inside = null, ?Scope $scope = null): void
 	{
 		$seenAttributes = [];
 		/** @noinspection PhpPossiblePolymorphicInvocationInspection */
@@ -67,7 +80,7 @@ class AttributeCheck extends BaseCheck
 				$this->checkAttribute($fileName, $attribute, $node, $seenAttributes, $inside, $scope);
 			}
 		}
-    }
+	}
 
 	/**
 	 * @param string $fileName
@@ -78,52 +91,82 @@ class AttributeCheck extends BaseCheck
 	 * @param Scope|null $scope
 	 * @return void
 	 */
-    private function checkAttribute(string $fileName, NodeAttribute $attribute, Node $node, array &$seenAttributes, ?ClassLike $inside = null, ?Scope $scope = null): void
-    {
-		$attributeClass = $this->verifyAttributeClass($fileName, $attribute);
-		if ($attributeClass === null) {
+	private function checkAttribute(string $fileName, NodeAttribute $attribute, Node $node, array &$seenAttributes, ?ClassLike $inside = null, ?Scope $scope = null): void
+	{
+		$attributeName = $attribute->name->toString();
+		$attributeClass = $this->symbolTable->getAbstractedClass($attributeName);
+
+		if (is_null($attributeClass)) {
+			$this->emitError($fileName, $node, ErrorConstants::TYPE_UNKNOWN_CLASS, "Attribute class $attributeName does not exist");
 			return;
 		}
 
-		$this->verifyAttributeRepeatability($fileName, $attribute, $attributeClass, $seenAttributes);
-		$this->verifyAttributeTarget($fileName, $attribute, $attributeClass, $node);
-		$this->runInstantiationCheck($fileName, $attribute, $inside, $scope);
-    }
+		$attributeAttribute = $this->findAttributeAttribute($attributeClass);
+		if (is_null($attributeAttribute)) {
+			$this->emitError($fileName, $node, ErrorConstants::TYPE_ATTRIBUTE_NOT_ATTRIBUTE, "Class $attributeName is not an attribute");
+			return;
+		}
 
-	private function verifyAttributeClass(string $fileName, NodeAttribute $attribute): ?Class_
+		$this->validateAttributeArguments($fileName, $attribute, $inside, $scope);
+
+		$flags = $this->getAttributeFlags($attributeAttribute, $inside, $scope);
+
+		if (!is_null($flags)) {
+			$this->validateAttributeTarget($node, $flags, $fileName, $attributeName);
+			$this->validateAttributeRepeatability($fileName, $attribute, $flags, $seenAttributes);
+		}
+	}
+
+	private function getAttributeFlags(AttributeInterface $attributeAttribute, ?ClassLike $inside, ?Scope $scope): ?int
 	{
-		$attributeName = $attribute->name->toString();
-		$attributeClass = $this->symbolTable->getClass($attributeName);
+		$argumentExpressions = $attributeAttribute->getArgumentExpressions();
 
-		if ($attributeClass === null) {
-			$this->emitError($fileName, $attribute->name, ErrorConstants::TYPE_UNKNOWN_CLASS, "Attribute class $attributeName does not exist");
+		if (empty($argumentExpressions)) {
+			return Attribute::TARGET_ALL;
+		}
+
+		if (count($argumentExpressions) != 1) {
 			return null;
 		}
 
-		if (!$this->isAttributeClass($attributeClass)) {
-			$this->emitError($fileName, $attribute->name, ErrorConstants::TYPE_ATTRIBUTE_NOT_ATTRIBUTE, "Class $attributeName is not an attribute");
+		try {
+			$argumentValue = $this->constantExpressionEvaluator->evaluate($argumentExpressions[0], $inside, $scope);
+
+			return is_int($argumentValue) ? $argumentValue : null;
+		} catch (ConstExprEvaluationException) {
 			return null;
 		}
-		return $attributeClass;
 	}
 
-	private function verifyAttributeRepeatability(string $fileName, NodeAttribute $attribute, Class_ $attributeClass, array &$seenAttributes): void
+	private function findAttributeAttribute(ClassInterface $class): ?AttributeInterface
 	{
-		$attributeName = $attribute->name->toString();
-		if (isset($seenAttributes[$attributeName]) && !$this->isAttributeRepeatable($attributeClass)) {
-			$this->emitError($fileName, $attribute->name, ErrorConstants::TYPE_ATTRIBUTE_NOT_REPEATABLE, "Attribute " . $attributeName . " is not repeatable");
+		foreach ($class->getAttributes() as $classAttribute) {
+			if ($classAttribute->getName() === Attribute::class) {
+				return $classAttribute;
+			}
 		}
-		$seenAttributes[$attributeName] = true;
+		return null;
 	}
 
-	private function verifyAttributeTarget(string $fileName, NodeAttribute $attribute, Class_ $attributeClass, Node $node): void
+
+	/**
+	 * @param Node $node
+	 * @return int
+	 */
+	private function getNodeTargetFlag(Node $node): int
 	{
-		if (!$this->hasValidTarget($attributeClass, $node)) {
-			$this->emitError($fileName, $attribute->name, ErrorConstants::TYPE_ATTRIBUTE_WRONG_TARGET, "Attribute " . $attribute->name->toString() . " cannot be used on this type of declaration");
-		}
+		return match (get_class($node)) {
+			Class_::class, Interface_::class, Trait_::class, Enum_::class => Attribute::TARGET_CLASS,
+			Function_::class => Attribute::TARGET_FUNCTION,
+			ClassMethod::class => Attribute::TARGET_METHOD,
+			Property::class => Attribute::TARGET_PROPERTY,
+			ClassConst::class => Attribute::TARGET_CLASS_CONSTANT,
+			Param::class => Attribute::TARGET_PARAMETER,
+			default => 0,
+		};
 	}
 
-	private function runInstantiationCheck(string $fileName, NodeAttribute $attribute, ?ClassLike $inside, ?Scope $scope): void
+	private function validateAttributeArguments(string $fileName, NodeAttribute $attribute, ?ClassLike $inside, ?Scope $scope): void
 	{
 		$new = new Node\Expr\New_(
 			$attribute->name,
@@ -132,114 +175,111 @@ class AttributeCheck extends BaseCheck
 		$this->instantiationCheck->run($fileName, $new, $inside, $scope);
 	}
 
-    /**
-     * @param Class_ $class
-     * @return bool
-     */
-    private function isAttributeClass(Class_ $class): bool
-    {
-		return Util::getPhpAttribute(Attribute::class, $class->attrGroups) !== null;
-    }
+	/**
+	 * @param Node $node
+	 * @param int $attributeAttributeFlags
+	 * @param string $fileName
+	 * @param string $attributeName
+	 * @return void
+	 */
+	public function validateAttributeTarget(Node $node, int $attributeAttributeFlags, string $fileName, string $attributeName): void
+	{
+		if (!($this->getNodeTargetFlag($node) & $attributeAttributeFlags)) {
+			$this->emitError($fileName, $node, ErrorConstants::TYPE_ATTRIBUTE_WRONG_TARGET, "Attribute $attributeName cannot be applied to target " . $node->getType());
+		}
+	}
 
-    /**
-     * @param Class_ $attributeClass
-     * @param Node $node
-     * @return bool
-     */
-    private function hasValidTarget(Class_ $attributeClass, Node $node): bool
-    {
-        $supportedTargets = $this->getAttributeTargets($attributeClass);
-        $nodeTarget = $this->getNodeTargetFlag($node);
+	private function validateAttributeRepeatability(string $fileName, NodeAttribute $attribute, int $attributeAttributeFlags, array &$seenAttributes): void
+	{
+		$attributeName = $attribute->name->toString();
+		if (isset($seenAttributes[$attributeName]) && !($attributeAttributeFlags & Attribute::IS_REPEATABLE)) {
+			$this->emitError($fileName, $attribute->name, ErrorConstants::TYPE_ATTRIBUTE_NOT_REPEATABLE, "Attribute " . $attributeName . " is not repeatable");
+		}
+		$seenAttributes[$attributeName] = true;
+	}
+}
 
-        return ($supportedTargets & $nodeTarget) !== 0;
-    }
+readonly class ConstantExpressionEvaluator {
+	public function __construct(private SymbolTable $symbolTable) {}
+	/**
+	 * @throws ConstExprEvaluationException
+	 */
+	public function evaluate(Expr $expr, ?ClassLike $inside, ?Scope $scope) {
+		$evaluator = new ConstExprEvaluator(
+			fn($unhandledExpr) => $this->fallbackEvaluator($unhandledExpr, $inside, $scope),
+		);
 
-    /**
-     * @param Class_ $attributeClass
-     * @return int
-     */
-    private function getAttributeTargets(Class_ $attributeClass): int
-    {
-        return $this->getAttributeFlags($attributeClass) & Attribute::TARGET_ALL;
-    }
+		return $evaluator->evaluateSilently($expr);
+	}
 
-    /**
-     * @param Class_ $attributeClass
-     * @return int
-     */
-    private function getAttributeFlags(Class_ $attributeClass): int
-    {
-        if ($attributeClass->name->toString() == Attribute::class) {
-            return Attribute::TARGET_CLASS;
-        }
+	/**
+	 * @throws ConstExprEvaluationException
+	 */
+	private function fallbackEvaluator(Expr $expr, ?ClassLike $inside, ?Scope $scope) {
+		// TODO(shayman@bamboohr.com): 1. Handle infinite recursion of constant references
+		// 2. Implement or remove cases
+		if ($expr instanceof Node\Scalar\MagicConst) {
+			throw new ConstExprEvaluationException();
+		} else if ($expr instanceof Expr\ConstFetch) {
+			throw new ConstExprEvaluationException();
+		} else if ($expr instanceof Expr\ClassConstFetch) {
+			return $this->evaluateClassConstFetch($expr, $inside, $scope);
+		} else if ($expr instanceof New_) {
+			throw new ConstExprEvaluationException();
+		} else if ($expr instanceof PropertyFetch) {
+			throw new ConstExprEvaluationException();
+		}
 
-        $attributeAttribute = Util::getPhpAttribute(Attribute::class, $attributeClass->attrGroups);
+		throw new ConstExprEvaluationException();
+	}
 
-        if ($attributeAttribute && !empty($attributeAttribute->args)) {
-            $arg = $attributeAttribute->args[0]->value;
-            return $this->evaluateAttributeFlags($arg);
-        }
+	/**
+	 * @throws ConstExprEvaluationException
+	 * @throws InvalidArgumentException
+	 */
+	private function evaluateClassConstFetch(Expr $expr, ?ClassLike $inside, ?Scope $scope) {
+		$className = $this->resolveClassName($expr->class, $inside, $scope);
+		$name = $this->resolveName($expr->name, $inside, $scope);
+		return $this->resolveValue($className, $name);
+	}
 
-        return Attribute::TARGET_ALL;
-    }
+	/**
+	 * @throws ConstExprEvaluationException
+	 */
+	private function resolveClassName(Expr|Name $class, ?ClassLike $inside, ?Scope $scope): string {
+		if ($class instanceof Name) {
+			return match ($class->toString()) {
+				"self", "static" => $inside->name->toString(),
+				"parent" => $inside->extends->toString(),
+				default => $class->toString(),
+			};
+		} else {
+			return $this->evaluate($class->expr, $inside, $scope);
+		}
+	}
 
-    /**
-     * @param Class_ $attributeClass
-     * @return bool
-     */
-    private function isAttributeRepeatable(Class_ $attributeClass): bool
-    {
-        return ($this->getAttributeFlags($attributeClass) & Attribute::IS_REPEATABLE) !== 0;
-    }
+	/**
+	 * @throws ConstExprEvaluationException
+	 */
+	private function resolveName(Expr|Error|Identifier $name, ?ClassLike $inside, ?Scope $scope) {
+		if ($name instanceof Identifier) {
+			return $name->toString();
+		} else {
+			return $this->evaluate($name, $inside, $scope);
+		}
+	}
 
-    /**
-     * @param Node\Expr $expr
-     * @return int
-     */
-    private function evaluateAttributeFlags(Node\Expr $expr): int
-    {
-        if ($expr instanceof Node\Expr\BinaryOp\BitwiseOr) {
-            return $this->evaluateAttributeFlags($expr->left) | $this->evaluateAttributeFlags($expr->right);
-        }
+	/**
+	 * @throws InvalidArgumentException
+	 */
+	private function resolveValue(string $class, string $name) {
+		if ($name == "class") {
+			return $class;
+		}
 
-        if ($expr instanceof Node\Expr\ClassConstFetch) {
-            if ($expr->class->toString() === 'Attribute' || $expr->class->toString() === Attribute::class) {
-				return match ($expr->name->toString()) {
-					'TARGET_CLASS' => Attribute::TARGET_CLASS,
-					'TARGET_FUNCTION' => Attribute::TARGET_FUNCTION,
-					'TARGET_METHOD' => Attribute::TARGET_METHOD,
-					'TARGET_PROPERTY' => Attribute::TARGET_PROPERTY,
-					'TARGET_CLASS_CONSTANT' => Attribute::TARGET_CLASS_CONSTANT,
-					'TARGET_PARAMETER' => Attribute::TARGET_PARAMETER,
-					'TARGET_ALL' => Attribute::TARGET_ALL,
-					'IS_REPEATABLE' => Attribute::IS_REPEATABLE,
-					default => 0,
-				};
-            }
-        }
+		/** @var ClassInterface $classInterface */
+		$classInterface = $this->symbolTable->getAbstractedClass($class);
 
-        if ($expr instanceof Node\Scalar\LNumber) {
-            return $expr->value;
-        }
-
-        // Unknown or unsupported expression type, return 0 to cause a validation failure.
-        return 0;
-    }
-
-    /**
-     * @param Node $node
-     * @return int
-     */
-    private function getNodeTargetFlag(Node $node): int
-    {
-        return match (get_class($node)) {
-            Class_::class, Interface_::class, Trait_::class, Enum_::class => Attribute::TARGET_CLASS,
-            Function_::class => Attribute::TARGET_FUNCTION,
-            ClassMethod::class => Attribute::TARGET_METHOD,
-            Property::class => Attribute::TARGET_PROPERTY,
-            ClassConst::class => Attribute::TARGET_CLASS_CONSTANT,
-            Param::class => Attribute::TARGET_PARAMETER,
-            default => 0,
-        };
-    }
+		return $classInterface->getConstant($name);
+	}
 }

--- a/src/Checks/AttributeCheck.php
+++ b/src/Checks/AttributeCheck.php
@@ -1,0 +1,245 @@
+<?php
+
+namespace BambooHR\Guardrail\Checks;
+
+use BambooHR\Guardrail\Output\OutputInterface;
+use BambooHR\Guardrail\Scope;
+use BambooHR\Guardrail\SymbolTable\SymbolTable;
+use BambooHR\Guardrail\Util;
+use PhpParser\Node;
+use PhpParser\Node\Attribute as NodeAttribute;
+use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassConst;
+use PhpParser\Node\Stmt\Property;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\Interface_;
+use PhpParser\Node\Stmt\Trait_;
+use PhpParser\Node\Stmt\Enum_;
+use Attribute;
+
+class AttributeCheck extends BaseCheck
+{
+	private InstantiationCheck $instantiationCheck;
+
+	public function __construct(SymbolTable $symbolTable, OutputInterface $doc) {
+		parent::__construct($symbolTable, $doc);
+
+		$this->instantiationCheck = new InstantiationCheck($symbolTable, $doc);
+	}
+
+	/**
+     * getCheckNodeTypes
+     *
+     * @return string[]
+     */
+    public function getCheckNodeTypes(): array
+	{
+        return [
+            Function_::class,
+            Class_::class,
+            ClassConst::class,
+            Property::class,
+            ClassMethod::class,
+            Param::class,
+            Interface_::class,
+            Trait_::class,
+            Enum_::class
+        ];
+    }
+
+    /**
+     * @param string         $fileName The name of the file we are parsing
+     * @param Node           $node     Instance of the Node
+     * @param ClassLike|null $inside   Instance of the ClassLike (the class we are parsing) [optional]
+     * @param Scope|null     $scope    Instance of the Scope (all variables in the current state) [optional]
+     *
+     * @return void
+     */
+    public function run($fileName, Node $node, ?ClassLike $inside = null, ?Scope $scope = null): void
+	{
+		$seenAttributes = [];
+		/** @noinspection PhpPossiblePolymorphicInvocationInspection */
+		foreach ($node->attrGroups as $attrGroup) {
+			foreach ($attrGroup->attrs as $attribute) {
+				$this->checkAttribute($fileName, $attribute, $node, $seenAttributes, $inside, $scope);
+			}
+		}
+    }
+
+	/**
+	 * @param string $fileName
+	 * @param NodeAttribute $attribute
+	 * @param Node $node
+	 * @param array $seenAttributes
+	 * @param ClassLike|null $inside
+	 * @param Scope|null $scope
+	 * @return void
+	 */
+    private function checkAttribute(string $fileName, NodeAttribute $attribute, Node $node, array &$seenAttributes, ?ClassLike $inside = null, ?Scope $scope = null): void
+    {
+		$attributeClass = $this->verifyAttributeClass($fileName, $attribute);
+		if ($attributeClass === null) {
+			return;
+		}
+
+		$this->verifyAttributeRepeatability($fileName, $attribute, $attributeClass, $seenAttributes);
+		$this->verifyAttributeTarget($fileName, $attribute, $attributeClass, $node);
+		$this->runInstantiationCheck($fileName, $attribute, $inside, $scope);
+    }
+
+	private function verifyAttributeClass(string $fileName, NodeAttribute $attribute): ?Class_
+	{
+		$attributeName = $attribute->name->toString();
+		$attributeClass = $this->symbolTable->getClass($attributeName);
+
+		if ($attributeClass === null) {
+			$this->emitError($fileName, $attribute->name, ErrorConstants::TYPE_UNKNOWN_CLASS, "Attribute class $attributeName does not exist");
+			return null;
+		}
+
+		if (!$this->isAttributeClass($attributeClass)) {
+			$this->emitError($fileName, $attribute->name, ErrorConstants::TYPE_ATTRIBUTE_NOT_ATTRIBUTE, "Class $attributeName is not an attribute");
+			return null;
+		}
+		return $attributeClass;
+	}
+
+	private function verifyAttributeRepeatability(string $fileName, NodeAttribute $attribute, Class_ $attributeClass, array &$seenAttributes): void
+	{
+		$attributeName = $attribute->name->toString();
+		if (isset($seenAttributes[$attributeName]) && !$this->isAttributeRepeatable($attributeClass)) {
+			$this->emitError($fileName, $attribute->name, ErrorConstants::TYPE_ATTRIBUTE_NOT_REPEATABLE, "Attribute " . $attributeName . " is not repeatable");
+		}
+		$seenAttributes[$attributeName] = true;
+	}
+
+	private function verifyAttributeTarget(string $fileName, NodeAttribute $attribute, Class_ $attributeClass, Node $node): void
+	{
+		if (!$this->hasValidTarget($attributeClass, $node)) {
+			$this->emitError($fileName, $attribute->name, ErrorConstants::TYPE_ATTRIBUTE_WRONG_TARGET, "Attribute " . $attribute->name->toString() . " cannot be used on this type of declaration");
+		}
+	}
+
+	private function runInstantiationCheck(string $fileName, NodeAttribute $attribute, ?ClassLike $inside, ?Scope $scope): void
+	{
+		$new = new Node\Expr\New_(
+			$attribute->name,
+			$attribute->args
+		);
+		$this->instantiationCheck->run($fileName, $new, $inside, $scope);
+	}
+
+    /**
+     * @param Class_ $class
+     * @return bool
+     */
+    private function isAttributeClass(Class_ $class): bool
+    {
+		return Util::getPhpAttribute(Attribute::class, $class->attrGroups) !== null;
+    }
+
+    /**
+     * @param Class_ $attributeClass
+     * @param Node $node
+     * @return bool
+     */
+    private function hasValidTarget(Class_ $attributeClass, Node $node): bool
+    {
+        $supportedTargets = $this->getAttributeTargets($attributeClass);
+        $nodeTarget = $this->getNodeTargetFlag($node);
+
+        return ($supportedTargets & $nodeTarget) !== 0;
+    }
+
+    /**
+     * @param Class_ $attributeClass
+     * @return int
+     */
+    private function getAttributeTargets(Class_ $attributeClass): int
+    {
+        return $this->getAttributeFlags($attributeClass) & Attribute::TARGET_ALL;
+    }
+
+    /**
+     * @param Class_ $attributeClass
+     * @return int
+     */
+    private function getAttributeFlags(Class_ $attributeClass): int
+    {
+        if ($attributeClass->name->toString() == Attribute::class) {
+            return Attribute::TARGET_CLASS;
+        }
+
+        $attributeAttribute = Util::getPhpAttribute(Attribute::class, $attributeClass->attrGroups);
+
+        if ($attributeAttribute && !empty($attributeAttribute->args)) {
+            $arg = $attributeAttribute->args[0]->value;
+            return $this->evaluateAttributeFlags($arg);
+        }
+
+        return Attribute::TARGET_ALL;
+    }
+
+    /**
+     * @param Class_ $attributeClass
+     * @return bool
+     */
+    private function isAttributeRepeatable(Class_ $attributeClass): bool
+    {
+        return ($this->getAttributeFlags($attributeClass) & Attribute::IS_REPEATABLE) !== 0;
+    }
+
+    /**
+     * @param Node\Expr $expr
+     * @return int
+     */
+    private function evaluateAttributeFlags(Node\Expr $expr): int
+    {
+        if ($expr instanceof Node\Expr\BinaryOp\BitwiseOr) {
+            return $this->evaluateAttributeFlags($expr->left) | $this->evaluateAttributeFlags($expr->right);
+        }
+
+        if ($expr instanceof Node\Expr\ClassConstFetch) {
+            if ($expr->class->toString() === 'Attribute' || $expr->class->toString() === Attribute::class) {
+				return match ($expr->name->toString()) {
+					'TARGET_CLASS' => Attribute::TARGET_CLASS,
+					'TARGET_FUNCTION' => Attribute::TARGET_FUNCTION,
+					'TARGET_METHOD' => Attribute::TARGET_METHOD,
+					'TARGET_PROPERTY' => Attribute::TARGET_PROPERTY,
+					'TARGET_CLASS_CONSTANT' => Attribute::TARGET_CLASS_CONSTANT,
+					'TARGET_PARAMETER' => Attribute::TARGET_PARAMETER,
+					'TARGET_ALL' => Attribute::TARGET_ALL,
+					'IS_REPEATABLE' => Attribute::IS_REPEATABLE,
+					default => 0,
+				};
+            }
+        }
+
+        if ($expr instanceof Node\Scalar\LNumber) {
+            return $expr->value;
+        }
+
+        // Unknown or unsupported expression type, return 0 to cause a validation failure.
+        return 0;
+    }
+
+    /**
+     * @param Node $node
+     * @return int
+     */
+    private function getNodeTargetFlag(Node $node): int
+    {
+        return match (get_class($node)) {
+            Class_::class, Interface_::class, Trait_::class, Enum_::class => Attribute::TARGET_CLASS,
+            Function_::class => Attribute::TARGET_FUNCTION,
+            ClassMethod::class => Attribute::TARGET_METHOD,
+            Property::class => Attribute::TARGET_PROPERTY,
+            ClassConst::class => Attribute::TARGET_CLASS_CONSTANT,
+            Param::class => Attribute::TARGET_PARAMETER,
+            default => 0,
+        };
+    }
+}

--- a/src/Checks/AttributeCheck.php
+++ b/src/Checks/AttributeCheck.php
@@ -93,18 +93,18 @@ class AttributeCheck extends BaseCheck
 
 	private function getAttributeFlags(AttributeInterface $attributeAttribute, ?ClassLike $inside, ?Scope $scope): ?int
 	{
-		$argumentExpressions = $attributeAttribute->getArgumentExpressions();
+		$arguments = $attributeAttribute->getArguments();
 
-		if (empty($argumentExpressions)) {
+		if (empty($arguments)) {
 			return Attribute::TARGET_ALL;
 		}
 
-		if (count($argumentExpressions) != 1) {
+		if (count($arguments) != 1) {
 			return null;
 		}
 
 		try {
-			$argumentValue = $this->constantExpressionEvaluator->evaluate($argumentExpressions[0], $inside, $scope);
+			$argumentValue = $this->constantExpressionEvaluator->evaluate($arguments[0]->value);
 
 			return is_int($argumentValue) ? $argumentValue : null;
 		} catch (ConstExprEvaluationException) {
@@ -115,7 +115,7 @@ class AttributeCheck extends BaseCheck
 	private function findAttributeAttribute(ClassInterface $class): ?AttributeInterface
 	{
 		foreach ($class->getAttributes() as $classAttribute) {
-			if ($classAttribute->getName() === Attribute::class) {
+			if ($classAttribute->getClassName() === Attribute::class) {
 				return $classAttribute;
 			}
 		}

--- a/src/Checks/ErrorConstants.php
+++ b/src/Checks/ErrorConstants.php
@@ -84,6 +84,11 @@ class ErrorConstants {
 	const TYPE_VARIABLE_FUNCTION_NAME = 'Standard.VariableFunctionCall';
 	const TYPE_VARIABLE_VARIABLE = 'Standard.VariableVariable';
 	const TYPE_COUNTABLE_EMPTINESS_CHECK = 'Standard.Countable.Emptiness';
+
+	const TYPE_ATTRIBUTE_NOT_ATTRIBUTE = 'Standard.Attribute.NotAttribute';
+	const TYPE_ATTRIBUTE_WRONG_TARGET = 'Standard.Attribute.WrongTarget';
+	const TYPE_ATTRIBUTE_NOT_REPEATABLE = 'Standard.Attribute.NotRepeatable';
+
 	const TYPE_OPEN_API_ATTRIBUTE_DOCUMENTATION_CHECK = 'Standard.OpenApiAttribute.Documentation';
 	const TYPE_OPEN_API_ATTRIBUTE_MISSING_REQUIRED_EXTENSION_PROPERTY = 'Standard.OpenApiAttribute.MissingRequiredExtensionProperty';
 	const TYPE_SERVICE_METHOD_DOCUMENTATION_CHECK = 'Standard.ServiceMethod.Documentation';

--- a/src/ConstantExpressionEvaluator.php
+++ b/src/ConstantExpressionEvaluator.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace BambooHR\Guardrail;
+
+use BambooHR\Guardrail\Abstractions\ClassInterface;
+use BambooHR\Guardrail\SymbolTable\SymbolTable;
+use InvalidArgumentException;
+use PhpParser\ConstExprEvaluationException;
+use PhpParser\ConstExprEvaluator;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\Error;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+
+/**
+ * Enhances PHP-Parser's `ConstExprEvaluator` to evaluate constant expressions, with added
+ * support for basic class constant lookups (e.g., `ExampleClass::EXAMPLE_CONSTANT`) resolved
+ * from the symbol table.
+ *
+ * Currently, it shares the following limitations with `ConstExprEvaluator` and does not support:
+ * - Magic constants (e.g., `__DIR__`, `__FILE__`).
+ * - Global constants (e.g., `PHP_VERSION`), except for `null`, `true`, and `false`.
+ * - Enums and most class constant lookups (e.g., `self::CONSTANT`, `"MyClass"::CONSTANT`, `MyClass":{$constantName}`).
+ * - `new` expressions in constant contexts (PHP 8.1+).
+ * - Property fetches on enums in constant contexts (PHP 8.2+).
+ */
+readonly class ConstantExpressionEvaluator {
+	public function __construct(private SymbolTable $symbolTable) {}
+	/**
+	 * @throws ConstExprEvaluationException
+	 */
+	public function evaluate(Expr $expr): mixed {
+		$evaluator = new ConstExprEvaluator(
+			fn($unhandledExpr) => $this->fallbackEvaluator($unhandledExpr),
+		);
+
+		return $evaluator->evaluateSilently($expr);
+	}
+
+	/**
+	 * @throws ConstExprEvaluationException
+	 */
+	private function fallbackEvaluator(Expr $expr) {
+		if ($expr instanceof Expr\ClassConstFetch) {
+			return $this->evaluateClassConstFetch($expr);
+		} else {
+			throw new ConstExprEvaluationException();
+		}
+	}
+
+	/**
+	 * @throws ConstExprEvaluationException
+	 * @throws InvalidArgumentException
+	 */
+	private function evaluateClassConstFetch(ClassConstFetch $expr) {
+		$className = $this->resolveClassName($expr->class);
+		$constantName = $this->resolveConstantName($expr->name);
+		return $this->resolveValue($className, $constantName);
+	}
+
+	/**
+	 * @throws ConstExprEvaluationException
+	 */
+	private function resolveClassName(Expr|Name $class): string {
+		if ($class instanceof Name) {
+			return match ($class->toString()) {
+				"this", "self", "static", "parent" => throw new ConstExprEvaluationException(),
+				default => $class->toString()
+			};
+		} else {
+			return $this->evaluate($class);
+		}
+	}
+
+	/**
+	 * @throws ConstExprEvaluationException
+	 */
+	private function resolveConstantName(Expr|Error|Identifier $name): string {
+		if ($name instanceof Identifier) {
+			return $name->toString();
+		} else {
+			return $this->evaluate($name);
+		}
+	}
+
+	/**
+	 * @throws ConstExprEvaluationException
+	 */
+	private function resolveValue(string $className, string $constantName) {
+		if ($constantName == "class") {
+			return $className;
+		}
+
+		/** @var ClassInterface $classInterface */
+		$classInterface = $this->symbolTable->getAbstractedClass($className);
+
+		return $this->evaluate($classInterface->getConstantValueExpression($constantName));
+	}
+}

--- a/src/ConstantExpressionEvaluator.php
+++ b/src/ConstantExpressionEvaluator.php
@@ -87,7 +87,7 @@ readonly class ConstantExpressionEvaluator {
 	/**
 	 * @throws ConstExprEvaluationException
 	 */
-	private function resolveValue(string $className, string $constantName) {
+	private function resolveValue(string $className, string $constantName): mixed {
 		if ($constantName == "class") {
 			return $className;
 		}

--- a/src/NodeVisitors/StaticAnalyzer.php
+++ b/src/NodeVisitors/StaticAnalyzer.php
@@ -49,7 +49,6 @@ use BambooHR\Guardrail\Checks\UseStatementCaseCheck;
 use BambooHR\Guardrail\Checks\OpenApiAttributeDocumentationCheck;
 use BambooHR\Guardrail\Config;
 use BambooHR\Guardrail\Evaluators as Ev;
-use BambooHR\Guardrail\Evaluators\ExpressionInterface;
 use BambooHR\Guardrail\Metrics\MetricOutputInterface;
 use BambooHR\Guardrail\Output\OutputInterface;
 use BambooHR\Guardrail\Scope\Scope;

--- a/src/NodeVisitors/StaticAnalyzer.php
+++ b/src/NodeVisitors/StaticAnalyzer.php
@@ -6,6 +6,7 @@
  */
 
 use BambooHR\Guardrail\Checks\AccessingSuperGlobalsCheck;
+use BambooHR\Guardrail\Checks\AttributeCheck;
 use BambooHR\Guardrail\Checks\BackTickOperatorCheck;
 use BambooHR\Guardrail\Checks\BreakCheck;
 use BambooHR\Guardrail\Checks\CatchCheck;
@@ -164,6 +165,7 @@ class StaticAnalyzer extends NodeVisitorAbstract
 			new OpenApiAttributeDocumentationCheck($this->index, $output, $metricOutput),
 			new ServiceMethodDocumentationCheck($this->index, $output, $metricOutput),
 			//new ClassStoredAsVariableCheck($this->index, $output)
+			new AttributeCheck($this->index, $output),
 		];
 
 		$checkers = array_merge($checkers, $config->getPlugins($this->index, $output));

--- a/tests/units/Abstractions/AttributeAbstractionTest.php
+++ b/tests/units/Abstractions/AttributeAbstractionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace BambooHR\Guardrail\Tests\Abstractions;
+
+use BambooHR\Guardrail\Abstractions\AttributeAbstraction;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PHPUnit\Framework\TestCase;
+
+class AttributeAbstractionTest extends TestCase {
+	public function testGetClassName() {
+		$abstraction = new AttributeAbstraction(
+			new Attribute(
+				new Name('MyAttribute'),
+				[]
+			)
+		);
+		$this->assertEquals('MyAttribute', $abstraction->getClassName());
+	}
+
+	public function testGetArguments() {
+		$args = [
+			new Arg(new String_('value1')),
+			new Arg(new String_('value2'), name: new Identifier('named'))
+		];
+		$attributeNode = new Attribute(
+			new Name('MyAttribute'),
+			[
+				new Arg(new String_('value1')),
+				new Arg(new String_('value2'), name: new Identifier('named'))
+			]
+		);
+		$abstraction = new AttributeAbstraction($attributeNode);
+		$this->assertEquals($args, $abstraction->getArguments());
+	}
+
+	public function testGetArgumentsEmpty() {
+		$attributeNode = new Attribute(
+			new Name('MyAttribute'),
+			[]
+		);
+		$abstraction = new AttributeAbstraction($attributeNode);
+		$this->assertEmpty($abstraction->getArguments());
+	}
+}

--- a/tests/units/Abstractions/ClassAbstractionTest.php
+++ b/tests/units/Abstractions/ClassAbstractionTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace BambooHR\Guardrail\Tests\Abstractions;
+
+use BambooHR\Guardrail\Abstractions\AttributeAbstraction;
+use BambooHR\Guardrail\Abstractions\ClassAbstraction;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Const_;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassConst;
+use PHPUnit\Framework\TestCase;
+
+class ClassAbstractionTest extends TestCase
+{
+	public function testGetAttributesReturnsAttributes()
+	{
+		$classAbstraction = new ClassAbstraction(
+			new Class_('MyClass', [
+				'attrGroups' => [
+					new AttributeGroup([
+						new Attribute(new Name('MyAttribute'))
+					])
+				]
+			])
+		);
+
+		$this->assertEquals(
+			[
+				new AttributeAbstraction(
+					new Attribute(new Name('MyAttribute'))
+				)
+			],
+			$classAbstraction->getAttributes()
+		);
+	}
+
+	public function testGetAttributesReturnsEmptyArrayWhenNoAttributes()
+	{
+		$classAbstraction = new ClassAbstraction(new Class_('MyClass'));
+		$this->assertEquals([], $classAbstraction->getAttributes());
+	}
+
+	public function testGetConstantValueExpressionReturnsExpression()
+	{
+		$constantValueExpression = new String_('my_value');
+		$classAbstraction = new ClassAbstraction(
+			new Class_('MyClass', [
+				'stmts' => [
+					new ClassConst([
+						new Const_('MY_CONST', $constantValueExpression)
+					])
+				]
+			])
+		);
+		$this->assertSame($constantValueExpression, $classAbstraction->getConstantValueExpression('MY_CONST'));
+	}
+
+	public function testGetConstantValueExpressionReturnsNullForNonExistentConstant()
+	{
+		$classAbstraction = new ClassAbstraction(new Class_('MyClass'));
+		$this->assertNull($classAbstraction->getConstantValueExpression('NON_EXISTENT'));
+	}
+}

--- a/tests/units/Abstractions/ClassAbstractionTest.php
+++ b/tests/units/Abstractions/ClassAbstractionTest.php
@@ -7,16 +7,18 @@ use BambooHR\Guardrail\Abstractions\ClassAbstraction;
 use PhpParser\Node\Attribute;
 use PhpParser\Node\AttributeGroup;
 use PhpParser\Node\Const_;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassConst;
+use PhpParser\Node\Stmt\Enum_;
+use PhpParser\Node\Stmt\EnumCase;
 use PHPUnit\Framework\TestCase;
 
-class ClassAbstractionTest extends TestCase
-{
-	public function testGetAttributesReturnsAttributes()
-	{
+class ClassAbstractionTest extends TestCase {
+	public function testGetAttributesReturnsAttributes() {
 		$classAbstraction = new ClassAbstraction(
 			new Class_('MyClass', [
 				'attrGroups' => [
@@ -37,14 +39,12 @@ class ClassAbstractionTest extends TestCase
 		);
 	}
 
-	public function testGetAttributesReturnsEmptyArrayWhenNoAttributes()
-	{
+	public function testGetAttributesReturnsEmptyArrayWhenNoAttributes() {
 		$classAbstraction = new ClassAbstraction(new Class_('MyClass'));
 		$this->assertEquals([], $classAbstraction->getAttributes());
 	}
 
-	public function testGetConstantValueExpressionReturnsExpression()
-	{
+	public function testGetConstantValueExpressionReturnsExpression() {
 		$constantValueExpression = new String_('my_value');
 		$classAbstraction = new ClassAbstraction(
 			new Class_('MyClass', [
@@ -58,9 +58,51 @@ class ClassAbstractionTest extends TestCase
 		$this->assertSame($constantValueExpression, $classAbstraction->getConstantValueExpression('MY_CONST'));
 	}
 
-	public function testGetConstantValueExpressionReturnsNullForNonExistentConstant()
-	{
+	public function testGetConstantValueExpressionReturnsNullForNonExistentConstant() {
 		$classAbstraction = new ClassAbstraction(new Class_('MyClass'));
 		$this->assertNull($classAbstraction->getConstantValueExpression('NON_EXISTENT'));
+	}
+
+	public function testGetConstantValueExpressionForBackedEnum() {
+		$caseValue = new String_('B');
+		$enum = new Enum_('MyEnum', [
+			'scalarType' => new Identifier('string'),
+			'stmts' => [
+				new EnumCase('MyCase', $caseValue)
+			]
+		]);
+		$classAbstraction = new ClassAbstraction($enum);
+		$this->assertSame($caseValue, $classAbstraction->getConstantValueExpression('MyCase'));
+	}
+
+	public function testGetConstantValueExpressionForPureEnum() {
+		$enum = new Enum_('MyPureEnum', [
+			'stmts' => [
+				new EnumCase('MyCase', null)
+			]
+		]);
+		$enum->namespacedName = new Name('MyPureEnum');
+		$classAbstraction = new ClassAbstraction($enum);
+
+		$expected = new ClassConstFetch(
+			new Name('MyPureEnum'),
+			new Identifier('MyCase')
+		);
+
+		$this->assertEquals($expected, $classAbstraction->getConstantValueExpression('MyCase'));
+	}
+
+	public function testGetConstantValueExpressionForConstantInEnum() {
+		$constantValueExpression = new String_('my_value');
+		$enum = new Enum_('MyEnum', [
+			'stmts' => [
+				new ClassConst([
+					new Const_('MY_CONST', $constantValueExpression)
+				]),
+				new EnumCase('MyCase', new String_('C'))
+			]
+		]);
+		$classAbstraction = new ClassAbstraction($enum);
+		$this->assertSame($constantValueExpression, $classAbstraction->getConstantValueExpression('MY_CONST'));
 	}
 }

--- a/tests/units/Abstractions/ReflectedAttributeTest.php
+++ b/tests/units/Abstractions/ReflectedAttributeTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace BambooHR\Guardrail\Tests\Abstractions;
+
+use BambooHR\Guardrail\Abstractions\ReflectedAttribute;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\LNumber;
+use PhpParser\Node\Scalar\String_;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Attribute;
+
+#[Attribute]
+class TestAttributeForReflectedAttributeTest {
+    public function __construct(public string $value, public int $number = 42) {}
+}
+
+#[TestAttributeForReflectedAttributeTest("hello", number: 99)]
+class ClassWithReflectedAttribute {}
+
+#[TestAttributeForReflectedAttributeTest("world")]
+class ClassWithReflectedAttributeDefault {}
+
+
+class ReflectedAttributeTest extends TestCase {
+    public function testGetClassName() {
+        $reflectionClass = new ReflectionClass(ClassWithReflectedAttribute::class);
+        $reflectionAttribute = $reflectionClass->getAttributes()[0];
+        $reflectedAttribute = new ReflectedAttribute($reflectionAttribute);
+
+        $this->assertEquals(TestAttributeForReflectedAttributeTest::class, $reflectedAttribute->getClassName());
+    }
+
+    public function testGetArguments() {
+        $reflectionClass = new ReflectionClass(ClassWithReflectedAttribute::class);
+        $reflectionAttribute = $reflectionClass->getAttributes()[0];
+        $reflectedAttribute = new ReflectedAttribute($reflectionAttribute);
+
+        $expectedArgs = [
+            new Arg(new String_('hello')),
+            new Arg(new LNumber(99), name: new Identifier('number'))
+        ];
+
+        $this->assertEquals($expectedArgs, $reflectedAttribute->getArguments());
+    }
+
+    public function testGetArgumentsDoesNotReturnDefaultedParameters() {
+        $reflectionClass = new ReflectionClass(ClassWithReflectedAttributeDefault::class);
+        $reflectionAttribute = $reflectionClass->getAttributes()[0];
+        $reflectedAttribute = new ReflectedAttribute($reflectionAttribute);
+
+        $expectedArgs = [
+            new Arg(new String_('world'))
+        ];
+
+        $this->assertEquals($expectedArgs, $reflectedAttribute->getArguments());
+    }
+}

--- a/tests/units/Abstractions/ReflectedClassTest.php
+++ b/tests/units/Abstractions/ReflectedClassTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace BambooHR\Guardrail\Tests\Abstractions;
+
+use BambooHR\Guardrail\Abstractions\ReflectedAttribute;
+use BambooHR\Guardrail\Abstractions\ReflectedClass;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\DNumber;
+use PhpParser\Node\Scalar\LNumber;
+use PhpParser\Node\Scalar\String_;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Attribute;
+
+#[Attribute]
+class TestAttributeForReflectedTest
+{
+	public function __construct(public string $value)
+	{
+	}
+}
+
+#[TestAttributeForReflectedTest("hello")]
+class ClassWithAttributeForReflectedTest
+{
+}
+
+class ClassWithoutAttributesForReflectedTest
+{
+}
+
+class ClassWithConstantsForReflectedTest
+{
+	const TEST_STRING = "string value";
+	const TEST_INT = 42;
+	const TEST_FLOAT = 3.14;
+	const TEST_BOOL_TRUE = true;
+	const TEST_BOOL_FALSE = false;
+	const TEST_NULL = null;
+	const TEST_ARRAY = ["foo" => "bar", 1 => 2];
+}
+
+class ReflectedClassTest extends TestCase
+{
+
+	public function testGetAttributes()
+	{
+		$reflectionClass = new ReflectionClass(ClassWithAttributeForReflectedTest::class);
+		$reflectedClass = new ReflectedClass(new ReflectionClass(ClassWithAttributeForReflectedTest::class));
+		$this->assertEquals(
+			[new ReflectedAttribute($reflectionClass->getAttributes()[0])],
+			$reflectedClass->getAttributes()
+		);
+	}
+
+	public function testGetAttributesReturnsEmptyArray()
+	{
+		$reflectedClass = new ReflectedClass(new ReflectionClass(ClassWithoutAttributesForReflectedTest::class));
+		$this->assertEquals([], $reflectedClass->getAttributes());
+	}
+
+	/**
+	 * @dataProvider constantValueProvider
+	 */
+	public function testGetConstantValueExpression($constantName, $expectedNode)
+	{
+		$reflectedClass = new ReflectedClass(new ReflectionClass(ClassWithConstantsForReflectedTest::class));
+		$this->assertEquals($expectedNode, $reflectedClass->getConstantValueExpression($constantName));
+	}
+
+	public function constantValueProvider(): array
+	{
+		return [
+			'string' => ['TEST_STRING', new String_("string value")],
+			'integer' => ['TEST_INT', new LNumber(42)],
+			'float' => ['TEST_FLOAT', new DNumber(3.14)],
+			'true' => ['TEST_BOOL_TRUE', new ConstFetch(new Name('true'))],
+			'false' => ['TEST_BOOL_FALSE', new ConstFetch(new Name('false'))],
+			'null' => ['TEST_NULL', new ConstFetch(new Name('null'))],
+			'array' => ['TEST_ARRAY', new Array_([
+				new ArrayItem(new String_('bar'), new String_('foo')),
+				new ArrayItem(new LNumber(2), new LNumber(1))
+			])],
+		];
+	}
+
+	public function testGetConstantValueExpressionForNonExistent()
+	{
+		$reflectedClass = new ReflectedClass(new ReflectionClass(ClassWithConstantsForReflectedTest::class));
+		$this->assertNull($reflectedClass->getConstantValueExpression('NON_EXISTENT_CONST'));
+	}
+}

--- a/tests/units/Abstractions/ReflectedClassTest.php
+++ b/tests/units/Abstractions/ReflectedClassTest.php
@@ -16,24 +16,18 @@ use ReflectionClass;
 use Attribute;
 
 #[Attribute]
-class TestAttributeForReflectedTest
-{
+class TestAttributeForReflectedTest {
 	public function __construct(public string $value)
 	{
 	}
 }
 
 #[TestAttributeForReflectedTest("hello")]
-class ClassWithAttributeForReflectedTest
-{
-}
+class ClassWithAttributeForReflectedTest {}
 
-class ClassWithoutAttributesForReflectedTest
-{
-}
+class ClassWithoutAttributesForReflectedTest {}
 
-class ClassWithConstantsForReflectedTest
-{
+class ClassWithConstantsForReflectedTest {
 	const TEST_STRING = "string value";
 	const TEST_INT = 42;
 	const TEST_FLOAT = 3.14;
@@ -43,11 +37,9 @@ class ClassWithConstantsForReflectedTest
 	const TEST_ARRAY = ["foo" => "bar", 1 => 2];
 }
 
-class ReflectedClassTest extends TestCase
-{
+class ReflectedClassTest extends TestCase {
 
-	public function testGetAttributes()
-	{
+	public function testGetAttributes() {
 		$reflectionClass = new ReflectionClass(ClassWithAttributeForReflectedTest::class);
 		$reflectedClass = new ReflectedClass(new ReflectionClass(ClassWithAttributeForReflectedTest::class));
 		$this->assertEquals(
@@ -56,8 +48,7 @@ class ReflectedClassTest extends TestCase
 		);
 	}
 
-	public function testGetAttributesReturnsEmptyArray()
-	{
+	public function testGetAttributesReturnsEmptyArray() {
 		$reflectedClass = new ReflectedClass(new ReflectionClass(ClassWithoutAttributesForReflectedTest::class));
 		$this->assertEquals([], $reflectedClass->getAttributes());
 	}
@@ -65,14 +56,12 @@ class ReflectedClassTest extends TestCase
 	/**
 	 * @dataProvider constantValueProvider
 	 */
-	public function testGetConstantValueExpression($constantName, $expectedNode)
-	{
+	public function testGetConstantValueExpression($constantName, $expectedNode) {
 		$reflectedClass = new ReflectedClass(new ReflectionClass(ClassWithConstantsForReflectedTest::class));
 		$this->assertEquals($expectedNode, $reflectedClass->getConstantValueExpression($constantName));
 	}
 
-	public function constantValueProvider(): array
-	{
+	public function constantValueProvider(): array {
 		return [
 			'string' => ['TEST_STRING', new String_("string value")],
 			'integer' => ['TEST_INT', new LNumber(42)],
@@ -87,8 +76,7 @@ class ReflectedClassTest extends TestCase
 		];
 	}
 
-	public function testGetConstantValueExpressionForNonExistent()
-	{
+	public function testGetConstantValueExpressionForNonExistent() {
 		$reflectedClass = new ReflectedClass(new ReflectionClass(ClassWithConstantsForReflectedTest::class));
 		$this->assertNull($reflectedClass->getConstantValueExpression('NON_EXISTENT_CONST'));
 	}

--- a/tests/units/Checks/TestAttributeCheck.php
+++ b/tests/units/Checks/TestAttributeCheck.php
@@ -6,58 +6,49 @@ use BambooHR\Guardrail\Checks\ErrorConstants;
 use BambooHR\Guardrail\Tests\TestSuiteSetup;
 
 
-class TestAttributeCheck extends TestSuiteSetup
-{
-    public function testValidAttributeDoesNotEmitError()
-    {
+class TestAttributeCheck extends TestSuiteSetup {
+    public function testValidAttributeDoesNotEmitError() {
         $output = $this->analyzeFileToOutput('.1.inc', []);
         $this->assertEquals(0, $output->getErrorCount());
     }
 
-    public function testUndefinedAttributeEmitsError()
-    {
+    public function testUndefinedAttributeEmitsError() {
         $output = $this->analyzeFileToOutput('.2.inc', [ErrorConstants::TYPE_UNKNOWN_CLASS]);
         $counts = $output->getCounts();
         $this->assertEquals(1, $counts[ErrorConstants::TYPE_UNKNOWN_CLASS] ?? 0);
     }
 
-    public function testClassThatIsNotAnAttributeEmitsError()
-    {
+    public function testClassThatIsNotAnAttributeEmitsError() {
         $output = $this->analyzeFileToOutput('.3.inc', [ErrorConstants::TYPE_ATTRIBUTE_NOT_ATTRIBUTE]);
         $counts = $output->getCounts();
         $this->assertEquals(1, $counts[ErrorConstants::TYPE_ATTRIBUTE_NOT_ATTRIBUTE] ?? 0);
     }
 
-    public function testAttributeOnWrongTargetEmitsError()
-    {
+    public function testAttributeOnWrongTargetEmitsError() {
         $output = $this->analyzeFileToOutput('.4.inc', [ErrorConstants::TYPE_ATTRIBUTE_WRONG_TARGET]);
         $counts = $output->getCounts();
         $this->assertEquals(1, $counts[ErrorConstants::TYPE_ATTRIBUTE_WRONG_TARGET] ?? 0);
     }
 
-    public function testNonRepeatableAttributeEmitsError()
-    {
+    public function testNonRepeatableAttributeEmitsError() {
         $output = $this->analyzeFileToOutput('.5.inc', [ErrorConstants::TYPE_ATTRIBUTE_NOT_REPEATABLE]);
         $counts = $output->getCounts();
         $this->assertEquals(1, $counts[ErrorConstants::TYPE_ATTRIBUTE_NOT_REPEATABLE] ?? 0);
     }
 
-    public function testAttributeWithPrivateConstructorEmitsError()
-    {
+    public function testAttributeWithPrivateConstructorEmitsError() {
         $output = $this->analyzeFileToOutput('.6.inc', [ErrorConstants::TYPE_SCOPE_ERROR]);
         $counts = $output->getCounts();
         $this->assertEquals(1, $counts[ErrorConstants::TYPE_SCOPE_ERROR] ?? 0);
     }
 
-    public function testWrongNumberOfConstructorParamsEmitsError()
-    {
+    public function testWrongNumberOfConstructorParamsEmitsError() {
         $output = $this->analyzeFileToOutput('.7.inc', [ErrorConstants::TYPE_SIGNATURE_COUNT]);
         $counts = $output->getCounts();
         $this->assertEquals(1, $counts[ErrorConstants::TYPE_SIGNATURE_COUNT] ?? 0);
     }
 
-    public function testWrongConstructorParamTypeEmitsError()
-    {
+    public function testWrongConstructorParamTypeEmitsError() {
         $output = $this->analyzeFileToOutput('.8.inc', [ErrorConstants::TYPE_SIGNATURE_TYPE]);
         $counts = $output->getCounts();
         $this->assertEquals(1, $counts[ErrorConstants::TYPE_SIGNATURE_TYPE] ?? 0);

--- a/tests/units/Checks/TestAttributeCheck.php
+++ b/tests/units/Checks/TestAttributeCheck.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace BambooHR\Guardrail\Tests\Checks;
+
+use BambooHR\Guardrail\Checks\ErrorConstants;
+use BambooHR\Guardrail\Tests\TestSuiteSetup;
+
+
+class TestAttributeCheck extends TestSuiteSetup
+{
+    public function testValidAttributeDoesNotEmitError()
+    {
+        $output = $this->analyzeFileToOutput('.1.inc', []);
+        $this->assertEquals(0, $output->getErrorCount());
+    }
+
+    public function testUndefinedAttributeEmitsError()
+    {
+        $output = $this->analyzeFileToOutput('.2.inc', [ErrorConstants::TYPE_UNKNOWN_CLASS]);
+        $counts = $output->getCounts();
+        $this->assertEquals(1, $counts[ErrorConstants::TYPE_UNKNOWN_CLASS] ?? 0);
+    }
+
+    public function testClassThatIsNotAnAttributeEmitsError()
+    {
+        $output = $this->analyzeFileToOutput('.3.inc', [ErrorConstants::TYPE_ATTRIBUTE_NOT_ATTRIBUTE]);
+        $counts = $output->getCounts();
+        $this->assertEquals(1, $counts[ErrorConstants::TYPE_ATTRIBUTE_NOT_ATTRIBUTE] ?? 0);
+    }
+
+    public function testAttributeOnWrongTargetEmitsError()
+    {
+        $output = $this->analyzeFileToOutput('.4.inc', [ErrorConstants::TYPE_ATTRIBUTE_WRONG_TARGET]);
+        $counts = $output->getCounts();
+        $this->assertEquals(1, $counts[ErrorConstants::TYPE_ATTRIBUTE_WRONG_TARGET] ?? 0);
+    }
+
+    public function testNonRepeatableAttributeEmitsError()
+    {
+        $output = $this->analyzeFileToOutput('.5.inc', [ErrorConstants::TYPE_ATTRIBUTE_NOT_REPEATABLE]);
+        $counts = $output->getCounts();
+        $this->assertEquals(1, $counts[ErrorConstants::TYPE_ATTRIBUTE_NOT_REPEATABLE] ?? 0);
+    }
+
+    public function testAttributeWithPrivateConstructorEmitsError()
+    {
+        $output = $this->analyzeFileToOutput('.6.inc', [ErrorConstants::TYPE_SCOPE_ERROR]);
+        $counts = $output->getCounts();
+        $this->assertEquals(1, $counts[ErrorConstants::TYPE_SCOPE_ERROR] ?? 0);
+    }
+
+    public function testWrongNumberOfConstructorParamsEmitsError()
+    {
+        $output = $this->analyzeFileToOutput('.7.inc', [ErrorConstants::TYPE_SIGNATURE_COUNT]);
+        $counts = $output->getCounts();
+        $this->assertEquals(1, $counts[ErrorConstants::TYPE_SIGNATURE_COUNT] ?? 0);
+    }
+
+    public function testWrongConstructorParamTypeEmitsError()
+    {
+        $output = $this->analyzeFileToOutput('.8.inc', [ErrorConstants::TYPE_SIGNATURE_TYPE]);
+        $counts = $output->getCounts();
+        $this->assertEquals(1, $counts[ErrorConstants::TYPE_SIGNATURE_TYPE] ?? 0);
+    }
+}

--- a/tests/units/Checks/TestData/TestAttributeCheck.1.inc
+++ b/tests/units/Checks/TestData/TestAttributeCheck.1.inc
@@ -1,0 +1,7 @@
+<?php
+
+#[\Attribute]
+class ValidAttribute {}
+
+#[ValidAttribute]
+class TestClassWithValidAttribute {}

--- a/tests/units/Checks/TestData/TestAttributeCheck.2.inc
+++ b/tests/units/Checks/TestData/TestAttributeCheck.2.inc
@@ -1,0 +1,5 @@
+<?php
+
+#[UndefinedAttribute]
+class TestClassForUndefinedAttribute {
+}

--- a/tests/units/Checks/TestData/TestAttributeCheck.3.inc
+++ b/tests/units/Checks/TestData/TestAttributeCheck.3.inc
@@ -1,0 +1,8 @@
+<?php
+
+class NotAnAttribute {
+}
+
+#[NotAnAttribute]
+class TestClassForNotAnAttribute {
+}

--- a/tests/units/Checks/TestData/TestAttributeCheck.4.inc
+++ b/tests/units/Checks/TestData/TestAttributeCheck.4.inc
@@ -1,0 +1,9 @@
+<?php
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class MethodOnlyAttribute {
+}
+
+#[MethodOnlyAttribute]
+class TestClassForWrongTarget {
+}

--- a/tests/units/Checks/TestData/TestAttributeCheck.5.inc
+++ b/tests/units/Checks/TestData/TestAttributeCheck.5.inc
@@ -1,0 +1,10 @@
+<?php
+
+#[Attribute]
+class NotRepeatableAttribute {
+}
+
+#[NotRepeatableAttribute]
+#[NotRepeatableAttribute]
+class TestClassForNotRepeatableAttribute {
+}

--- a/tests/units/Checks/TestData/TestAttributeCheck.6.inc
+++ b/tests/units/Checks/TestData/TestAttributeCheck.6.inc
@@ -1,0 +1,11 @@
+<?php
+
+#[Attribute]
+class PrivateConstructorAttribute {
+    private function __construct() {
+    }
+}
+
+#[PrivateConstructorAttribute]
+class TestClassForAttributeWithPrivateConstructor {
+}

--- a/tests/units/Checks/TestData/TestAttributeCheck.7.inc
+++ b/tests/units/Checks/TestData/TestAttributeCheck.7.inc
@@ -1,0 +1,11 @@
+<?php
+
+#[Attribute]
+class OneArgumentAttribute {
+    public function __construct(string $name) {
+    }
+}
+
+#[OneArgumentAttribute]
+class TestClassForWrongNumberOfArgs {
+}

--- a/tests/units/Checks/TestData/TestAttributeCheck.8.inc
+++ b/tests/units/Checks/TestData/TestAttributeCheck.8.inc
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+#[Attribute]
+class StringArgumentAttribute {
+    public function __construct(string $name) {
+    }
+}
+
+#[StringArgumentAttribute([])]
+class TestClassForWrongArgType {
+}

--- a/tests/units/ConstantExpressionEvaluatorTest.php
+++ b/tests/units/ConstantExpressionEvaluatorTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use BambooHR\Guardrail\Abstractions\ReflectedClass;
+use BambooHR\Guardrail\ConstantExpressionEvaluator;
+use BambooHR\Guardrail\SymbolTable\SymbolTable;
+use PhpParser\Node\Expr\BinaryOp\BitwiseOr;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name\FullyQualified;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ConstantExpressionEvaluatorTest extends TestCase {
+	private MockObject $symbolTable;
+	private ConstantExpressionEvaluator $evaluator;
+
+	public function setUp(): void {
+		$this->symbolTable = $this->createMock(SymbolTable::class);
+		$this->evaluator = new ConstantExpressionEvaluator($this->symbolTable);
+	}
+
+	public function testBasicClassConstantFetchEvaluation(): void {
+		$this->symbolTable
+			 ->expects($this->once())
+			 ->method('getAbstractedClass')
+			 ->with("Attribute")
+			 ->willReturn(new ReflectedClass(new ReflectionClass(Attribute::class)));
+
+		$this->assertEquals(
+			2,
+			$this->evaluator->evaluate(
+				new ClassConstFetch(
+					new FullyQualified('Attribute'),
+					new Identifier('TARGET_FUNCTION')
+				)
+			)
+		);
+	}
+
+	public function testClassConstantEvaluation(): void {
+		$this->assertEquals(
+			'MyClass',
+			$this->evaluator->evaluate(
+				new ClassConstFetch(
+					new FullyQualified('MyClass'),
+					new Identifier('class')
+				)
+			)
+		);
+	}
+
+	public function testBitwiseOrEvaluation(): void {
+		$this->symbolTable
+			->expects($this->exactly(2))
+			->method('getAbstractedClass')
+			->with("Attribute")
+			->willReturn(new ReflectedClass(new ReflectionClass(Attribute::class)));
+
+		$this->assertEquals(
+			6,
+			$this->evaluator->evaluate(
+				new BitwiseOr(
+					new ClassConstFetch(
+						new FullyQualified('Attribute'),
+						new Identifier('TARGET_FUNCTION')
+					),
+					new ClassConstFetch(
+						new FullyQualified('Attribute'),
+						new Identifier('TARGET_METHOD')
+					)
+				)
+			)
+		);
+	}
+}


### PR DESCRIPTION
 Key Changes:
   * New `AttributeCheck`: A new check has been added to validate the usage of attributes. It ensures that:
       * The attribute class exists and is itself a valid attribute (i.e., has the `#[Attribute]` attribute).
       * The attribute is applied to a valid target (class, method, property, etc.) according to its `Attribute::TARGET_`* flags.
       * Non-repeatable attributes are not used more than once on the same declaration.
       * The arguments passed to the attribute's constructor are valid (correct count, type, and visibility).

   * New `ConstantExpressionEvaluator`: To properly check attribute flags, a new evaluator for constant expressions has been implemented. It can resolve some `ClassConstFetch` expressions (e.g., `MyClass::MY_CONST`) and evaluate bitwise operations, allowing it to interpret flags like `Attribute::TARGET_CLASS | Attribute::TARGET_METHOD`.

   * Abstraction Layer Enhancements:
       * `ClassInterface`, `ClassAbstraction`, and `ReflectedClass` have been updated to provide methods for retrieving attributes (`getAttributes()`) and resolving the value expressions of constants (`getConstantValueExpression()`). This provides a unified way to analyze attributes from both source code (AST) and reflection.
       * New `AttributeInterface`, `AttributeAbstraction`, and `ReflectedAttribute` classes were created to abstract away the differences between AST nodes and reflected attributes.


   * Unit Tests: Unit tests have been added for the new attribute check, the constant expression evaluator, and the updated abstraction layer components.