### PR TITLE
fix(SPEED-2558): Fix error reporting to properly ignore suppressed errors

### DIFF
--- a/tests/units/Checks/TestData/TestFunctionCallCheck.11.inc
+++ b/tests/units/Checks/TestData/TestFunctionCallCheck.11.inc
@@ -1,0 +1,3 @@
+<?php
+
+preg_match('/unclosed bracket[/', null);

--- a/tests/units/Checks/TestFunctionCallCheck.php
+++ b/tests/units/Checks/TestFunctionCallCheck.php
@@ -2,6 +2,7 @@
 
 use BambooHR\Guardrail\Checks\ErrorConstants;
 use BambooHR\Guardrail\Tests\TestSuiteSetup;
+use BambooHR\Guardrail\CommandLineRunner;
 
 
 /**
@@ -17,7 +18,7 @@ class TestFunctionCallCheck extends TestSuiteSetup {
 	 * @return void
 	 * @rapid-unit Checks:FunctionCallCheck:Catches all dangerous method calls and emits errors
 	 */
-	public function testDangerousFunctionsEmitErrors() {
+	public function testDangerousFunctionsEmitErrors(): void {
 		$this->assertEquals(8, $this->runAnalyzerOnFile('.1.inc',ErrorConstants::TYPE_SECURITY_DANGEROUS));
 	}
 
@@ -27,7 +28,7 @@ class TestFunctionCallCheck extends TestSuiteSetup {
 	 * @return void
 	 * @rapid-unit Checks:FunctionCallCheck:Catches a function call without enough arguments
 	 */
-	public function testFunctionCallWithTooManyArgs() {
+	public function testFunctionCallWithTooManyArgs(): void {
 		$this->assertEquals(1, $this->runAnalyzerOnFile('.2.inc', ErrorConstants::TYPE_SIGNATURE_COUNT));
 	}
 
@@ -37,7 +38,7 @@ class TestFunctionCallCheck extends TestSuiteSetup {
 	 * @return void
 	 * @rapid-unit
 	 */
-	public function testCheckForDebugBackTraces() {
+	public function testCheckForDebugBackTraces(): void {
 		$this->assertEquals(6, $this->runAnalyzerOnFile('.3.inc', ErrorConstants::TYPE_DEBUG));
 	}
 
@@ -47,7 +48,7 @@ class TestFunctionCallCheck extends TestSuiteSetup {
 	 * @return void
 	 * @rapid-unit Checks:FunctionCallCheck:Catches a deprecated user function call and emits error
 	 */
-	public function testDeprecatedUserFunctionCall() {
+	public function testDeprecatedUserFunctionCall(): void {
 		$this->assertEquals(3, $this->runAnalyzerOnFile('.4.inc', ErrorConstants::TYPE_DEPRECATED_USER));
 	}
 
@@ -59,7 +60,7 @@ class TestFunctionCallCheck extends TestSuiteSetup {
 	 * @return void
 	 * @rapid-unit Checks:FunctionCallCheck:Catches a call to a missing function and emits error
 	 */
-	public function testUnknownFunctionCall() {
+	public function testUnknownFunctionCall(): void {
 		$this->assertEquals(1, $this->runAnalyzerOnFile('.5.inc', ErrorConstants::TYPE_UNKNOWN_FUNCTION));
 	}
 
@@ -68,7 +69,7 @@ class TestFunctionCallCheck extends TestSuiteSetup {
 	 *
 	 * @return void
 	 */
-	public function testVariableFunctionName() {
+	public function testVariableFunctionName(): void {
 		$this->assertEquals(1, $this->runAnalyzerOnFile('.6.inc', ErrorConstants::TYPE_VARIABLE_FUNCTION_NAME));
 	}
 
@@ -76,21 +77,21 @@ class TestFunctionCallCheck extends TestSuiteSetup {
 	 *
 	 * @return void
 	 */
-	public function testTimeZones() {
+	public function testTimeZones(): void {
 		$this->assertEquals(3, $this->runAnalyzerOnFile('.7.inc', ErrorConstants::TYPE_UNSAFE_TIME_ZONE));
 	}
 
 	/**
 	 * @return void
 	 */
-	public function testNamespaces() {
+	public function testNamespaces(): void {
 		$this->assertEquals(0, $this->runAnalyzerOnFile('.8.inc', ErrorConstants::TYPE_UNKNOWN_FUNCTION));
 	}
 
 	/**
 	 * @return void
 	 */
-	public function testUnionTypeHints() {
+	public function testUnionTypeHints(): void {
 		$this->assertEquals(1, $this->runAnalyzerOnFile('.9.inc', ErrorConstants::TYPE_SIGNATURE_TYPE));
 	}
 
@@ -98,7 +99,21 @@ class TestFunctionCallCheck extends TestSuiteSetup {
 	 * @return void
 	 * @rapid-unit Checks:FunctionCallCheck:Ensures that passing an object with a __toString method is allowed as a valid argument to a method or function with a string requirement
 	 */
-	public function testObjectWith__toStringMethod() {
+	public function testObjectWith__toStringMethod(): void {
 		$this->assertEquals(2, $this->runAnalyzerOnFile('.10.inc', ErrorConstants::TYPE_SIGNATURE_TYPE));
+	}
+	/**
+	 * Test that invalid regex patterns emit a Guardrail error instead of terminating
+	 *
+	 * @return void
+	 * @rapid-unit Checks:FunctionCallCheck:Properly handles invalid regex patterns
+	 */
+	public function testInvalidRegexPattern(): void {
+		// Explicitly override error handler to match CommandLineRunner error handler (have to do this with PHPUnit v9.x.x -- see https://docs.phpunit.de/en/10.5/error-handling.html for when we upgrade).
+		set_error_handler([CommandLineRunner::class, 'handleErrors'],  CommandLineRunner::ERROR_MASK);
+
+		$this->assertEquals(1, $this->runAnalyzerOnFile('.11.inc', ErrorConstants::TYPE_INCORRECT_REGEX));
+
+		restore_error_handler();
 	}
 }


### PR DESCRIPTION
https://bamboohr.atlassian.net/browse/SPEED-2558

This is a bit of a weird one. We need to properly ignore errors suppressed with the `@` operator. In my testing, there was some weirdness in how PHP was setting the error_reporting variable based on the flags I was passing in. The official [documentation](https://www.php.net/manual/en/language.operators.errorcontrol.php#:~:text=Prior%20to%20PHP,E_RECOVERABLE_ERROR%20%7C%20E_PARSE.) says it should always set it to `E_ERROR | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR | E_PARSE` on suppressed errors but I found that wasn't the case if you manually passed in `-d error_reporting=...` flags to phpunit (I was trying to suppress the deprecated warnings all over the place). It seemed to revert to the old behavior of setting it to 0. I've updated the code to check for both just in case.

There's also some weirdness in handling the custom error handling stuff. In PHPUnit v10+ you can force PHPUnit to respect any customer error handlers in our code but we're on v9. I had to manually update the test to explicitly change the error handler to what we're using in command line runner (and did some refactoring so the test could use the same code).