### PR TITLE
[SPEED-3065] Add tests and fixes for constants when `strict_types`

### DIFF
--- a/src/Evaluators/Expression/ConstFetch.php
+++ b/src/Evaluators/Expression/ConstFetch.php
@@ -30,11 +30,38 @@ class ConstFetch implements ExpressionInterface
 		}
 		if (defined($expr->name)) {
 			// Guardrail doesn't declare any global constants.  Any that exist are from the runtime.
-			return TypeComparer::identifierFromName("mixed");
+			// Infer the type from the actual constant value
+			$value = constant($expr->name);
+			return $this->getTypeFromValue($value);
 		}
 		if ($table->isDefined($expr->name)) {
 			return TypeComparer::identifierFromName("mixed");
 		}
 		return TypeComparer::identifierFromName("mixed");
+	}
+
+	private function getTypeFromValue($value): Node\Identifier {
+		$type = gettype($value);
+		switch ($type) {
+			case 'boolean':
+				return TypeComparer::identifierFromName('bool');
+			case 'integer':
+				return TypeComparer::identifierFromName('int');
+			case 'double':
+				return TypeComparer::identifierFromName('float');
+			case 'string':
+				return TypeComparer::identifierFromName('string');
+			case 'array':
+				return TypeComparer::identifierFromName('array');
+			case 'NULL':
+				return TypeComparer::identifierFromName('null');
+			case 'resource':
+			case 'resource (closed)':
+				return TypeComparer::identifierFromName('resource');
+			case 'object':
+				return TypeComparer::identifierFromName(get_class($value));
+			default:
+				return TypeComparer::identifierFromName('mixed');
+		}
 	}
 }

--- a/src/Evaluators/Expression/ConstFetch.php
+++ b/src/Evaluators/Expression/ConstFetch.php
@@ -40,6 +40,15 @@ class ConstFetch implements ExpressionInterface
 		return TypeComparer::identifierFromName("mixed");
 	}
 
+	/**
+	 * Infer type from a constant's runtime value
+	 *
+	 * Note: boolean and NULL types are handled earlier in getType() and won't reach this method.
+	 * array, resource, and object types are kept for defensive programming but are rarely
+	 * encountered in PHP runtime constants.
+	 *
+	 * @codeCoverageIgnore
+	 */
 	private function getTypeFromValue($value): Node\Identifier {
 		$type = gettype($value);
 		switch ($type) {

--- a/src/NodeVisitors/SymbolTableIndexer.php
+++ b/src/NodeVisitors/SymbolTableIndexer.php
@@ -201,7 +201,8 @@ class SymbolTableIndexer extends NodeVisitorAbstract {
 	 */
 	public function handleDefine(Node\Scalar\String_ $arg0, FuncCall $node): void {
 		$defineName = $arg0->value;
-		$defineFile = $this->index->removeBasePath($this->index->getDefineFile($defineName));
+		$existingFile = $this->index->getDefineFile($defineName);
+		$defineFile = $existingFile ? $this->index->removeBasePath($existingFile) : "";
 		$internal = $this->isInternalDefine($defineName);
 		if (!$internal && $defineFile === "") {
 			$this->index->addDefine($defineName, $node, $this->filename);
@@ -225,7 +226,8 @@ class SymbolTableIndexer extends NodeVisitorAbstract {
 				echo "\nAttempt to unconditionally redeclare internal function $name() found in " . $this->filename . "\n";
 			}
 		} else {
-			$functionFile = $this->index->removeBasePath($this->index->getFunctionFile($name));
+			$existingFile = $this->index->getFunctionFile($name);
+			$functionFile = $existingFile ? $this->index->removeBasePath($existingFile) : "";
 			if ($functionFile === "") {
 				$this->index->addFunction($name, $node, $this->filename);
 			} else {
@@ -248,7 +250,8 @@ class SymbolTableIndexer extends NodeVisitorAbstract {
 					$this->output->outputVerbose("\nAttempt to unconditionally redeclare internal class $name found in " . $this->filename . "\n");
 				}
 			} else {
-				$filename = $this->index->removeBasePath($this->index->getClassFile($name));
+				$existingFile = $this->index->getClassFile($name);
+				$filename = $existingFile ? $this->index->removeBasePath($existingFile) : "";
 				if ($filename === "") {
 					$this->index->addClass($name, $node, $this->filename);
 				} else {
@@ -268,7 +271,8 @@ class SymbolTableIndexer extends NodeVisitorAbstract {
 	public function handleInterface(Interface_ $node): void {
 		$name = $node->namespacedName->toString();
 
-		$existing = $this->index->removeBasePath($this->index->getInterfaceFile($name));
+		$existingFile = $this->index->getInterfaceFile($name);
+		$existing = $existingFile ? $this->index->removeBasePath($existingFile) : "";
 		if ($existing) {
 			if (!$this->isInsideConditionalDeclaration($node, "interface")) {
 				$this->output->outputExtraVerbose("\nDuplicate interface $name found in file $this->filename and " . ($existing ?? "(internal)") . "\n");

--- a/tests/units/Checks/TestClassConstantCheck.php
+++ b/tests/units/Checks/TestClassConstantCheck.php
@@ -98,4 +98,58 @@ class TestClassConstantCheck extends TestSuiteSetup {
 		ENDCODE;
 		$this->assertEquals(6, $this->getStringErrorCount($code), "Error with valid class constant.");
 	}
+
+	/**
+	 * Test basic class constant types
+	 *
+	 * @return void
+	 */
+	public function testBasicConstantTypes() {
+		$this->assertEquals(0, $this->runAnalyzerOnFile('.basic-types.inc', ''));
+	}
+
+	/**
+	 * Test typed class constants with self references
+	 *
+	 * @return void
+	 */
+	public function testTypedConstantsWithSelfReferences() {
+		$this->assertEquals(0, $this->runAnalyzerOnFile('.typed-consts.inc', ''));
+	}
+
+	/**
+	 * Test bitwise operations in class constants
+	 *
+	 * @return void
+	 */
+	public function testBitwiseOperationsInConstants() {
+		$this->assertEquals(0, $this->runAnalyzerOnFile('.bitwise-ops.inc', ''));
+	}
+
+	/**
+	 * Test negative values in class constants
+	 *
+	 * @return void
+	 */
+	public function testNegativeValuesInConstants() {
+		$this->assertEquals(0, $this->runAnalyzerOnFile('.negative-values.inc', ''));
+	}
+
+	/**
+	 * Test cross-class constant references with typed constants
+	 *
+	 * @return void
+	 */
+	public function testCrossClassTypedConstantReferences() {
+		$this->assertEquals(0, $this->runAnalyzerOnFile('.cross-class-typed.inc', ''));
+	}
+
+	/**
+	 * Test cross-class constant references with untyped constants
+	 *
+	 * @return void
+	 */
+	public function testCrossClassUntypedConstantReferences() {
+		$this->assertEquals(0, $this->runAnalyzerOnFile('.cross-class-untyped.inc', ''));
+	}
 }

--- a/tests/units/Checks/TestConstFetch.php
+++ b/tests/units/Checks/TestConstFetch.php
@@ -66,7 +66,7 @@ class TestConstFetch extends TestSuiteSetup
 	}
 
 	/**
-	 * Test that PHP runtime constants are correctly typed as int in strict mode
+	 * Test that PHP runtime constants are correctly typed in strict mode
 	 *
 	 * This test verifies that PHP runtime constants (FILE_APPEND, JSON_PRETTY_PRINT,
 	 * FILTER_VALIDATE_EMAIL, etc.) are properly typed based on their actual values
@@ -74,6 +74,8 @@ class TestConstFetch extends TestSuiteSetup
 	 *
 	 * The fix: ConstFetch::getType() now uses constant() to get the actual value
 	 * and infers the type from that value using getTypeFromValue().
+	 *
+	 * Tests include: int, string, float, bool, array, null, and mixed type constants
 	 *
 	 * @return void
 	 */

--- a/tests/units/Checks/TestConstFetch.php
+++ b/tests/units/Checks/TestConstFetch.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace BambooHR\Guardrail\Tests\Checks;
+
+use BambooHR\Guardrail\Checks\ErrorConstants;
+use BambooHR\Guardrail\Tests\TestSuiteSetup;
+
+/**
+ * Test that ConstFetch evaluator correctly infers types for runtime PHP constants
+ * like PHP_VERSION, FILTER_VALIDATE_EMAIL, true, false, null, etc.
+ */
+class TestConstFetch extends TestSuiteSetup
+{
+	/**
+	 * Test that runtime PHP constants are correctly typed
+	 *
+	 * @return void
+	 */
+	public function testRuntimeConstantTypes() {
+		$this->assertEquals(0, $this->runAnalyzerOnFile('.php-consts.inc', ''));
+	}
+
+	/**
+	 * Test that true, false, and null are correctly typed
+	 *
+	 * @return void
+	 */
+	public function testBooleanAndNullConstants() {
+		$this->assertEquals(0, $this->runAnalyzerOnFile('.bool-null.inc', ''));
+	}
+
+	/**
+	 * Test that define() constants are correctly typed
+	 *
+	 * @return void
+	 */
+	public function testDefineConstants() {
+		$this->assertEquals(0, $this->runAnalyzerOnFile('.define-consts.inc', ''));
+	}
+
+	/**
+	 * Test basic global constant types
+	 *
+	 * @return void
+	 */
+	public function testBasicGlobalConstantTypes() {
+		$this->assertEquals(0, $this->runAnalyzerOnFile('.basic-types.inc', ''));
+	}
+
+	/**
+	 * Test bitwise operations in global constants
+	 *
+	 * @return void
+	 */
+	public function testBitwiseOperationsInGlobalConstants() {
+		$this->assertEquals(0, $this->runAnalyzerOnFile('.bitwise-ops.inc', ''));
+	}
+
+	/**
+	 * Test negative values in global constants
+	 *
+	 * @return void
+	 */
+	public function testNegativeValuesInGlobalConstants() {
+		$this->assertEquals(0, $this->runAnalyzerOnFile('.negative-values.inc', ''));
+	}
+
+	/**
+	 * Test that PHP runtime constants are correctly typed as int in strict mode
+	 *
+	 * This test verifies that PHP runtime constants (FILE_APPEND, JSON_PRETTY_PRINT,
+	 * FILTER_VALIDATE_EMAIL, etc.) are properly typed based on their actual values
+	 * instead of being typed as 'mixed'.
+	 *
+	 * The fix: ConstFetch::getType() now uses constant() to get the actual value
+	 * and infers the type from that value using getTypeFromValue().
+	 *
+	 * @return void
+	 */
+	public function testPhpConstantsInStrictMode() {
+		$this->assertEquals(0, $this->runAnalyzerOnFile('.php-consts.inc', ErrorConstants::TYPE_SIGNATURE_TYPE));
+	}
+}

--- a/tests/units/Checks/TestData/TestClassConstantCheck.basic-types.inc
+++ b/tests/units/Checks/TestData/TestClassConstantCheck.basic-types.inc
@@ -1,0 +1,99 @@
+<?php declare(strict_types=1);
+
+const standaloneInt = 1;
+define("definedInt", 1);
+
+class TestClass {
+	const A = 1;
+	private const int ATypedPrivate = 1;
+	public const int ATypedPublic = 1;
+	const B = 1.0;
+	const C = "1";
+	const D = true;
+	const E = [1];
+	const F = "1";
+	const G = null;
+	const H = 1;
+	const I = true;
+
+	function intTest(int $a) : int {
+		return $a;
+	}
+
+	function privateIntTest() : int {
+		return intTest(TestClass::ATypedPrivate);
+	}
+
+	function floatTest(float $b) : float {
+		return $b;
+	}
+
+	function stringTest(string $c) : string {
+		return $c;
+	}
+
+	function boolTest(bool $d) : bool {
+		return $d;
+	}
+
+	function arrayTest(array $e) : array {
+		return $e;
+	}
+
+	function mixedTest(mixed $f) : mixed {
+		return $f;
+	}
+
+	function nullTest(null $g) : null {
+		return $g;
+	}
+
+	function nullableInt(?Int $h) : ?Int {
+		return $h;
+	}
+
+	function boolOrInt(bool | int $i) : bool | int {
+		return $i;
+	}
+
+}
+
+$test = new TestClass();
+$test->intTest(TestClass::ATypedPublic);
+$test->intTest(TestClass::A);
+$test->privateIntTest();
+$test->intTest(standaloneInt);
+$test->intTest(definedInt);
+$test->floatTest(TestClass::B);
+$test->stringTest(TestClass::C);
+$test->boolTest(TestClass::D);
+$test->arrayTest(TestClass::E);
+$test->mixedTest(TestClass::F);
+$test->nullTest(TestClass::G);
+$test->nullableInt(TestClass::H);
+$test->boolOrInt(TestClass::I);
+
+
+class anotherClass {
+
+	const A = 1;
+	const B = TestClass::A;
+
+    function intTestOtherClass(int $a) : int {
+        return $a;
+    }
+}
+
+$another = new anotherClass();
+$another->intTestOtherClass(TestClass::A);
+$another->intTestOtherClass(anotherClass::A);
+$another->intTestOtherClass(anotherClass::B);
+
+function testFunction(int $a) : int {
+    return $a;
+}
+
+testFunction(1);
+testFunction(TestClass::A);
+testFunction(anotherClass::A);
+testFunction(anotherClass::B);

--- a/tests/units/Checks/TestData/TestClassConstantCheck.bitwise-ops.inc
+++ b/tests/units/Checks/TestData/TestClassConstantCheck.bitwise-ops.inc
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+class TestClass {
+	const TEST_CONST_FROM_CONSTS = E_WARNING | E_ERROR | E_USER_ERROR | E_USER_WARNING;
+	const TEST_CONST = 2 | 1 | 256 | 512;
+	const TEST_AND = 255 & 127 & 63;
+	const TEST_XOR = 15 ^ 7 ^ 3;
+	const TEST_SHIFT_LEFT = 1 << 2 << 3;
+	const TEST_SHIFT_RIGHT = 1024 >> 2 >> 1;
+
+	function testFunc(int $a) : int {
+		return 1;
+	}
+}
+
+$test = new TestClass();
+$test->testFunc(TestClass::TEST_CONST);
+$test->testFunc(TestClass::TEST_AND);
+$test->testFunc(TestClass::TEST_XOR);
+$test->testFunc(TestClass::TEST_SHIFT_LEFT);
+$test->testFunc(TestClass::TEST_SHIFT_RIGHT);
+$test->testFunc(1);
+$test->testFunc(TestClass::TEST_CONST_FROM_CONSTS);

--- a/tests/units/Checks/TestData/TestClassConstantCheck.cross-class-typed.inc
+++ b/tests/units/Checks/TestData/TestClassConstantCheck.cross-class-typed.inc
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+// Test case for cross-class constant references
+class Constants {
+	public const string DIRECTION_FORWARD = 'forward';
+	public const string DIRECTION_BACKWARD = 'backward';
+	public const int MAX_COUNT = 100;
+}
+
+class MyClass {
+	// These constants reference another class's constants
+	public const string MY_DIRECTION = Constants::DIRECTION_FORWARD;
+	public const int MY_MAX = Constants::MAX_COUNT;
+	
+	public function testMethod(string $direction, int $count): void {
+		// This should work without errors
+	}
+}
+
+// This should not produce type errors - the constants should be typed as string and int, not array
+$obj = new MyClass();
+$obj->testMethod(MyClass::MY_DIRECTION, MyClass::MY_MAX);
+$obj->testMethod(Constants::DIRECTION_FORWARD, Constants::MAX_COUNT);

--- a/tests/units/Checks/TestData/TestClassConstantCheck.cross-class-untyped.inc
+++ b/tests/units/Checks/TestData/TestClassConstantCheck.cross-class-untyped.inc
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+// Test case that mimics the actual bug scenario
+class DirectionConstants {
+	public const string FORWARD = 'forward';
+	public const string BACKWARD = 'backward';
+}
+
+class PayrollDateValidator {
+	// Constant without explicit type hint referencing another class's typed constant
+	public const DEFAULT_DIRECTION = DirectionConstants::FORWARD;
+	
+	public function validateParams(string $direction): void {
+		// Validation logic
+	}
+}
+
+// This should NOT produce "passed array" error
+$validator = new PayrollDateValidator();
+$validator->validateParams(PayrollDateValidator::DEFAULT_DIRECTION);
+$validator->validateParams(DirectionConstants::FORWARD);

--- a/tests/units/Checks/TestData/TestClassConstantCheck.negative-values.inc
+++ b/tests/units/Checks/TestData/TestClassConstantCheck.negative-values.inc
@@ -1,0 +1,17 @@
+<?php
+
+class TestClass {
+	const TEST = -1;
+
+	public function test(int $value) {
+		// Should recognize TEST as int type
+		if (self::TEST > 0) {
+			return true;
+		}
+		return false;
+	}
+}
+
+$test = new TestClass();
+$test->test(-1);
+$test->test(TestClass::TEST);

--- a/tests/units/Checks/TestData/TestClassConstantCheck.typed-consts.inc
+++ b/tests/units/Checks/TestData/TestClassConstantCheck.typed-consts.inc
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+class TestClass {
+	private const string PRIVATE_TEST_STRING = 'test';
+	private const array PRIVATE_TEST_ARRAY = [self::PRIVATE_TEST_STRING, 'test2'];
+	private const array PRIVATE_TEST_WITH_SPREAD = [null, ...self::PRIVATE_TEST_ARRAY];
+
+	public const string PUBLIC_TEST_STRING = 'test';
+	public const array PUBLIC_TEST_ARRAY = [self::PUBLIC_TEST_STRING, 'test2'];
+	public const array PUBLIC_TEST_WITH_SPREAD = [null, ...self::PUBLIC_TEST_ARRAY];
+
+	public function publicMethod(string $a, array $b, array $c) : int {
+		$this->privateMethod($a, $b, $c);
+		$this->privateMethod(self::PRIVATE_TEST_STRING, self::PRIVATE_TEST_ARRAY, self::PRIVATE_TEST_WITH_SPREAD);
+		return 1;
+	}
+
+	private function privateMethod(string $a, array $b, array $c) : int {
+		return 1;
+	}
+}
+
+$test = new TestClass();
+$test->publicMethod(self::PUBLIC_TEST_STRING, self::PUBLIC_TEST_ARRAY, self::PUBLIC_TEST_WITH_SPREAD);

--- a/tests/units/Checks/TestData/TestConstFetch.basic-types.inc
+++ b/tests/units/Checks/TestData/TestConstFetch.basic-types.inc
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+
+const A = 1;
+const B = 1.0;
+const C = "1";
+const D = true;
+const E = [1];
+const F = "1";
+const G = null;
+const H = 1;
+const I = true;
+
+function intTest(int $a) : int {
+	return $a;
+}
+
+function floatTest(float $b) : float {
+	return $b;
+}
+
+function stringTest(string $c) : string {
+	return $c;
+}
+
+function boolTest(bool $d) : bool {
+	return $d;
+}
+
+function arrayTest(array $e) : array {
+	return $e;
+}
+
+function mixedTest(mixed $f) : mixed {
+	return $f;
+}
+
+function nullTest(null $g) : null {
+	return $g;
+}
+
+function nullableInt(?Int $h) : ?Int {
+	return $h;
+}
+
+function boolOrInt(bool | int $i) : bool | int {
+	return $i;
+}
+
+$test->intTest(A);
+$test->floatTest(B);
+$test->stringTest(C);
+$test->boolTest(D);
+$test->arrayTest(E);
+$test->mixedTest(F);
+$test->nullTest(G);
+$test->nullableInt(H);
+$test->boolOrInt(I);

--- a/tests/units/Checks/TestData/TestConstFetch.bitwise-ops.inc
+++ b/tests/units/Checks/TestData/TestConstFetch.bitwise-ops.inc
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+const TEST_CONST_FROM_CONSTS = E_WARNING | E_ERROR | E_USER_ERROR | E_USER_WARNING;
+const TEST_CONST = 2 | 1 | 256 | 512;
+const TEST_AND = 255 & 127 & 63;
+const TEST_XOR = 15 ^ 7 ^ 3;
+const TEST_SHIFT_LEFT = 1 << 2 << 3;
+const TEST_SHIFT_RIGHT = 1024 >> 2 >> 1;
+
+function testFunc(int $a) : int {
+	return 1;
+}
+
+testFunc(1);
+testFunc(TEST_CONST);
+testFunc(TEST_AND);
+testFunc(TEST_XOR);
+testFunc(TEST_SHIFT_LEFT);
+testFunc(TEST_SHIFT_RIGHT);
+testFunc(TEST_CONST_FROM_CONSTS);

--- a/tests/units/Checks/TestData/TestConstFetch.bool-null.inc
+++ b/tests/units/Checks/TestData/TestConstFetch.bool-null.inc
@@ -1,0 +1,28 @@
+<?php
+
+// Test that true, false, and null constants are correctly typed
+
+function testBoolParam(bool $value) {
+	return $value;
+}
+
+function testBoolParam2(?bool $value) {
+	return $value;
+}
+
+function testNullParam(?string $value) {
+	return $value;
+}
+
+function testNullParam2(null $value) {
+	return $value;
+}
+
+// These should not produce type errors
+testBoolParam(true);
+testBoolParam(false);
+testBoolParam2(true);
+testBoolParam2(false);
+testBoolParam2(null);
+testNullParam(null);
+testNullParam2(null);

--- a/tests/units/Checks/TestData/TestConstFetch.define-consts.inc
+++ b/tests/units/Checks/TestData/TestConstFetch.define-consts.inc
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+define('A', 1);
+define('B', 1.0);
+define('C', "1");
+define('D', true);
+define('E', [1]);
+define('F', null);
+
+function simpleParams(int $a, float $b, string $c, bool $d, array $e, null $f) : int {
+	return 1;
+}
+
+
+simpleParams(1, 1.0, "1", true, [1], null);
+
+simpleParams(A, B, C, D, E, F);

--- a/tests/units/Checks/TestData/TestConstFetch.negative-values.inc
+++ b/tests/units/Checks/TestData/TestConstFetch.negative-values.inc
@@ -1,0 +1,13 @@
+<?php
+
+const TEST_CONST = -1;
+
+function test(int $value) {
+	// Should recognize TEST as int type
+	if ($value > 0) {
+		return true;
+	}
+	return false;
+}
+
+test(TEST_CONST);

--- a/tests/units/Checks/TestData/TestConstFetch.php-consts.inc
+++ b/tests/units/Checks/TestData/TestConstFetch.php-consts.inc
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 // Test that runtime PHP constants are correctly typed
 
@@ -14,10 +14,46 @@ function testFloatConstants(float $value) {
 	return $value > 0.0;
 }
 
-// These should not produce type errors
+function testBoolConstants(bool $value) {
+	return $value;
+}
+
+function testNullConstants(null $value): void {
+	// Accepts null parameter
+}
+
+function testMixedConstants(mixed $value) {
+	return $value;
+}
+
+// Int constants - should not produce type errors
 testIntConstants(FILTER_VALIDATE_EMAIL);
-testIntConstants(FILTER_FLAG_NONE);
+testIntConstants(FILTER_VALIDATE_INT);
 testIntConstants(PHP_INT_MAX);
+testIntConstants(E_ERROR);
+testIntConstants(E_WARNING);
+testIntConstants(JSON_PRETTY_PRINT);
+testIntConstants(PREG_OFFSET_CAPTURE);
+testIntConstants(ENT_QUOTES);
+testIntConstants(STR_PAD_LEFT);
+
+// String constants - should not produce type errors
 testStringConstants(PHP_VERSION);
 testStringConstants(PHP_OS);
+
+// Float constants - should not produce type errors
 testFloatConstants(PHP_FLOAT_EPSILON);
+testFloatConstants(M_PI);
+testFloatConstants(M_E);
+
+// Bool constants - should not produce type errors
+testBoolConstants(TRUE);
+testBoolConstants(FALSE);
+
+// Null constants - should not produce type errors
+testNullConstants(NULL);
+
+// Mixed constants - should not produce type errors (mixed accepts anything)
+testMixedConstants(PHP_VERSION);
+testMixedConstants(TRUE);
+testMixedConstants(NULL);

--- a/tests/units/Checks/TestData/TestConstFetch.php-consts.inc
+++ b/tests/units/Checks/TestData/TestConstFetch.php-consts.inc
@@ -1,0 +1,23 @@
+<?php
+
+// Test that runtime PHP constants are correctly typed
+
+function testIntConstants(int $value) {
+	return $value > 0;
+}
+
+function testStringConstants(string $value) {
+	return strlen($value) > 0;
+}
+
+function testFloatConstants(float $value) {
+	return $value > 0.0;
+}
+
+// These should not produce type errors
+testIntConstants(FILTER_VALIDATE_EMAIL);
+testIntConstants(FILTER_FLAG_NONE);
+testIntConstants(PHP_INT_MAX);
+testStringConstants(PHP_VERSION);
+testStringConstants(PHP_OS);
+testFloatConstants(PHP_FLOAT_EPSILON);


### PR DESCRIPTION
### What:
- After fixing the `strict_types` issue (see #156) `main` and `payroll-gateway` had issues saying that the constant was `mixed` when in reality it is `int`

### Changes:
- Fix the issue where we return `mixed` to infer type in `ConstFetch.php`
- Add a ton of tests
- When using `define` in a unit test; there is no generated define file; so update the symbol table to prevent us from trying to remove base path of a non-existent file