### PR TITLE
[SPEED-3094] Support not having a `Return` or a `Throw` if an underlying function throws and is not caught

### DIFF
--- a/src/Checks/ReturnCheck.php
+++ b/src/Checks/ReturnCheck.php
@@ -247,26 +247,7 @@ class ReturnCheck extends BaseCheck {
 	 * @return bool
 	 */
 	private function allIfBranchesReturnOrThrow(Node\Stmt\If_ $ifStatement): bool {
-		if ($this->isConstantTrue($ifStatement->cond)) {
-			return $this->statementsAllReturnOrThrow($ifStatement->stmts);
-		}
-		if (!$ifStatement->else) {
-			return false;
-		}
-		if (!$this->statementsAllReturnOrThrow($ifStatement->stmts)) {
-			return false;
-		}
-		if (!$this->statementsAllReturnOrThrow($ifStatement->else->stmts)) {
-			return false;
-		}
-		if ($ifStatement->elseifs) {
-			foreach ($ifStatement->elseifs as $elseIf) {
-				if (!$this->statementsAllReturnOrThrow($elseIf->stmts)) {
-					return false;
-				}
-			}
-		}
-		return true;
+		return $this->checkIfBranches($ifStatement, false);
 	}
 
 	/**
@@ -277,20 +258,7 @@ class ReturnCheck extends BaseCheck {
 	 * @return bool
 	 */
 	private function allSwitchCasesReturnOrThrow(Node\Stmt\Switch_ $switchStatement): bool {
-		$hasDefault = false;
-		foreach ($switchStatement->cases as $case) {
-			if ($case->cond === null) {
-				$hasDefault = true;
-			}
-			$stmts = $case->stmts;
-			while (($last = end($stmts)) instanceof Node\Stmt\Break_ || $last instanceof Node\Stmt\Nop) {
-				$stmts = array_slice($stmts, 0, -1);
-			}
-			if ($stmts && !$this->statementsAllReturnOrThrow($stmts)) {
-				return false;
-			}
-		}
-		return $hasDefault;
+		return $this->checkSwitchCases($switchStatement, false);
 	}
 
 	/**
@@ -320,21 +288,7 @@ class ReturnCheck extends BaseCheck {
 	 * @return bool
 	 */
 	private function allTryCatchBranchesReturnOrThrow(Node\Stmt\TryCatch $tryCatch): bool {
-		// If finally block returns or throws, it overrides try/catch
-		if ($tryCatch->finally && $this->statementsAllReturnOrThrow($tryCatch->finally->stmts)) {
-			return true;
-		}
-
-		// Otherwise, both try and all catch blocks must return or throw
-		if (!$this->statementsAllReturnOrThrow($tryCatch->stmts)) {
-			return false;
-		}
-		foreach ($tryCatch->catches as $catch) {
-			if (!$this->statementsAllReturnOrThrow($catch->stmts)) {
-				return false;
-			}
-		}
-		return true;
+		return $this->checkTryCatchBranches($tryCatch, false);
 	}
 
 	/**
@@ -404,18 +358,13 @@ class ReturnCheck extends BaseCheck {
 			// Handle instance method calls
 			$type = $expr->var->getAttribute(\BambooHR\Guardrail\TypeComparer::INFERRED_TYPE_ATTR);
 			if ($type) {
-				// Handle union types by checking each type
 				$allThrow = false;
 				TypeComparer::forEachType($type, function ($typeNode) use ($expr, &$allThrow) {
 					$method = \BambooHR\Guardrail\Util::findAbstractedMethod(strval($typeNode), $expr->name, $this->symbolTable);
 					if ($method && $method instanceof \BambooHR\Guardrail\Abstractions\ClassMethod) {
-						$reflection = new \ReflectionClass($method);
-						$property = $reflection->getProperty('method');
-						$methodNode = $property->getValue($method);
-						if ($methodNode instanceof Node\Stmt\ClassMethod) {
-							if ($this->allPathsThrow($methodNode)) {
-								$allThrow = true;
-							}
+						$methodNode = $this->extractMethodNode($method);
+						if ($methodNode && $this->allPathsThrow($methodNode)) {
+							$allThrow = true;
 						}
 					}
 				});
@@ -427,10 +376,8 @@ class ReturnCheck extends BaseCheck {
 				$className = strval($expr->class);
 				$method = \BambooHR\Guardrail\Util::findAbstractedMethod($className, $expr->name, $this->symbolTable);
 				if ($method && $method instanceof \BambooHR\Guardrail\Abstractions\ClassMethod) {
-					$reflection = new \ReflectionClass($method);
-					$property = $reflection->getProperty('method');
-					$methodNode = $property->getValue($method);
-					if ($methodNode instanceof Node\Stmt\ClassMethod) {
+					$methodNode = $this->extractMethodNode($method);
+					if ($methodNode) {
 						return $this->allPathsThrow($methodNode);
 					}
 				}
@@ -489,26 +436,7 @@ class ReturnCheck extends BaseCheck {
 	 * @return bool
 	 */
 	private function allIfBranchesThrow(Node\Stmt\If_ $ifStatement): bool {
-		if ($this->isConstantTrue($ifStatement->cond)) {
-			return $this->statementsAllThrow($ifStatement->stmts);
-		}
-		if (!$ifStatement->else) {
-			return false;
-		}
-		if (!$this->statementsAllThrow($ifStatement->stmts)) {
-			return false;
-		}
-		if (!$this->statementsAllThrow($ifStatement->else->stmts)) {
-			return false;
-		}
-		if ($ifStatement->elseifs) {
-			foreach ($ifStatement->elseifs as $elseIf) {
-				if (!$this->statementsAllThrow($elseIf->stmts)) {
-					return false;
-				}
-			}
-		}
-		return true;
+		return $this->checkIfBranches($ifStatement, true);
 	}
 
 	/**
@@ -519,20 +447,7 @@ class ReturnCheck extends BaseCheck {
 	 * @return bool
 	 */
 	private function allSwitchCasesThrow(Node\Stmt\Switch_ $switchStatement): bool {
-		$hasDefault = false;
-		foreach ($switchStatement->cases as $case) {
-			if ($case->cond === null) {
-				$hasDefault = true;
-			}
-			$stmts = $case->stmts;
-			while (($last = end($stmts)) instanceof Node\Stmt\Break_ || $last instanceof Node\Stmt\Nop) {
-				$stmts = array_slice($stmts, 0, -1);
-			}
-			if ($stmts && !$this->statementsAllThrow($stmts)) {
-				return false;
-			}
-		}
-		return $hasDefault;
+		return $this->checkSwitchCases($switchStatement, true);
 	}
 
 	/**
@@ -543,20 +458,106 @@ class ReturnCheck extends BaseCheck {
 	 * @return bool
 	 */
 	private function allTryCatchBranchesThrow(Node\Stmt\TryCatch $tryCatch): bool {
-		// If finally block throws, it overrides try/catch
-		if ($tryCatch->finally && $this->statementsAllThrow($tryCatch->finally->stmts)) {
+		return $this->checkTryCatchBranches($tryCatch, true);
+	}
+
+	/**
+	 * Unified method to check if branches meet termination criteria
+	 *
+	 * @param Node\Stmt\If_ $ifStatement Instance of If_
+	 * @param bool           $throwOnly    If true, only throw counts; if false, return or throw counts
+	 *
+	 * @return bool
+	 */
+	private function checkIfBranches(Node\Stmt\If_ $ifStatement, bool $throwOnly): bool {
+		$checker = $throwOnly ? [$this, 'statementsAllThrow'] : [$this, 'statementsAllReturnOrThrow'];
+
+		if ($this->isConstantTrue($ifStatement->cond)) {
+			return $checker($ifStatement->stmts);
+		}
+		if (!$ifStatement->else) {
+			return false;
+		}
+		if (!$checker($ifStatement->stmts)) {
+			return false;
+		}
+		if (!$checker($ifStatement->else->stmts)) {
+			return false;
+		}
+		if ($ifStatement->elseifs) {
+			foreach ($ifStatement->elseifs as $elseIf) {
+				if (!$checker($elseIf->stmts)) {
+					return false;
+				}
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Unified method to check if switch cases meet termination criteria
+	 *
+	 * @param Node\Stmt\Switch_ $switchStatement Instance of Switch_
+	 * @param bool               $throwOnly        If true, only throw counts; if false, return or throw counts
+	 *
+	 * @return bool
+	 */
+	private function checkSwitchCases(Node\Stmt\Switch_ $switchStatement, bool $throwOnly): bool {
+		$checker = $throwOnly ? [$this, 'statementsAllThrow'] : [$this, 'statementsAllReturnOrThrow'];
+
+		$hasDefault = false;
+		foreach ($switchStatement->cases as $case) {
+			if ($case->cond === null) {
+				$hasDefault = true;
+			}
+			$stmts = $case->stmts;
+			while (($last = end($stmts)) instanceof Node\Stmt\Break_ || $last instanceof Node\Stmt\Nop) {
+				$stmts = array_slice($stmts, 0, -1);
+			}
+			if ($stmts && !$checker($stmts)) {
+				return false;
+			}
+		}
+		return $hasDefault;
+	}
+
+	/**
+	 * Unified method to check if try-catch branches meet termination criteria
+	 *
+	 * @param Node\Stmt\TryCatch $tryCatch  Instance of TryCatch
+	 * @param bool                $throwOnly If true, only throw counts; if false, return or throw counts
+	 *
+	 * @return bool
+	 */
+	private function checkTryCatchBranches(Node\Stmt\TryCatch $tryCatch, bool $throwOnly): bool {
+		$checker = $throwOnly ? [$this, 'statementsAllThrow'] : [$this, 'statementsAllReturnOrThrow'];
+
+		if ($tryCatch->finally && $checker($tryCatch->finally->stmts)) {
 			return true;
 		}
 
-		// Otherwise, both try and all catch blocks must throw
-		if (!$this->statementsAllThrow($tryCatch->stmts)) {
+		if (!$checker($tryCatch->stmts)) {
 			return false;
 		}
 		foreach ($tryCatch->catches as $catch) {
-			if (!$this->statementsAllThrow($catch->stmts)) {
+			if (!$checker($catch->stmts)) {
 				return false;
 			}
 		}
 		return true;
+	}
+
+	/**
+	 * Extract method node from a ClassMethod abstraction
+	 *
+	 * @param \BambooHR\Guardrail\Abstractions\ClassMethod $method
+	 *
+	 * @return Node\Stmt\ClassMethod|null
+	 */
+	private function extractMethodNode(\BambooHR\Guardrail\Abstractions\ClassMethod $method): ?Node\Stmt\ClassMethod {
+		$reflection = new \ReflectionClass($method);
+		$property = $reflection->getProperty('method');
+		$methodNode = $property->getValue($method);
+		return $methodNode instanceof Node\Stmt\ClassMethod ? $methodNode : null;
 	}
 }

--- a/src/Checks/ReturnCheck.php
+++ b/src/Checks/ReturnCheck.php
@@ -387,7 +387,7 @@ class ReturnCheck extends BaseCheck {
 			if ($name instanceof Node\Name) {
 				$function = $this->symbolTable->getAbstractedFunction(strval($name));
 				if ($function) {
-					// Check if the function body always throws/returns
+					// Check if the function body always throws (not just returns)
 					if ($function instanceof \BambooHR\Guardrail\Abstractions\FunctionAbstraction) {
 						// FunctionAbstraction wraps a Function_ node, we need to check if it always throws
 						// We can use reflection to get the function property
@@ -395,12 +395,168 @@ class ReturnCheck extends BaseCheck {
 						$property = $reflection->getProperty('function');
 						$functionNode = $property->getValue($function);
 						if ($functionNode instanceof Node\Stmt\Function_) {
-							return $this->allPathsReturnOrThrow($functionNode);
+							return $this->allPathsThrow($functionNode);
 						}
+					}
+				}
+			}
+		} elseif ($expr instanceof Node\Expr\MethodCall && $expr->name instanceof Node\Identifier) {
+			// Handle instance method calls
+			$type = $expr->var->getAttribute(\BambooHR\Guardrail\TypeComparer::INFERRED_TYPE_ATTR);
+			if ($type) {
+				// Handle union types by checking each type
+				$allThrow = false;
+				TypeComparer::forEachType($type, function ($typeNode) use ($expr, &$allThrow) {
+					$method = \BambooHR\Guardrail\Util::findAbstractedMethod(strval($typeNode), $expr->name, $this->symbolTable);
+					if ($method && $method instanceof \BambooHR\Guardrail\Abstractions\ClassMethod) {
+						$reflection = new \ReflectionClass($method);
+						$property = $reflection->getProperty('method');
+						$methodNode = $property->getValue($method);
+						if ($methodNode instanceof Node\Stmt\ClassMethod) {
+							if ($this->allPathsThrow($methodNode)) {
+								$allThrow = true;
+							}
+						}
+					}
+				});
+				return $allThrow;
+			}
+		} elseif ($expr instanceof Node\Expr\StaticCall && $expr->name instanceof Node\Identifier) {
+			// Handle static method calls
+			if ($expr->class instanceof Node\Name) {
+				$className = strval($expr->class);
+				$method = \BambooHR\Guardrail\Util::findAbstractedMethod($className, $expr->name, $this->symbolTable);
+				if ($method && $method instanceof \BambooHR\Guardrail\Abstractions\ClassMethod) {
+					$reflection = new \ReflectionClass($method);
+					$property = $reflection->getProperty('method');
+					$methodNode = $property->getValue($method);
+					if ($methodNode instanceof Node\Stmt\ClassMethod) {
+						return $this->allPathsThrow($methodNode);
 					}
 				}
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * Check if all code paths in a function throw an exception (not return)
+	 *
+	 * @param Node\FunctionLike $func The function to check
+	 *
+	 * @return bool
+	 */
+	private function allPathsThrow(Node\FunctionLike $func): bool {
+		$stmts = $func->getStmts();
+		if (!$stmts) {
+			return false;
+		}
+		return $this->statementsAllThrow($stmts);
+	}
+
+	/**
+	 * Check if all code paths in a list of statements throw (not return)
+	 *
+	 * @param array $stmts List of statements
+	 *
+	 * @return bool
+	 */
+	private function statementsAllThrow(array $stmts): bool {
+		$lastStatement = $this->getLastNonNopStatement($stmts);
+
+		if (!$lastStatement) {
+			return false;
+		} elseif ($lastStatement instanceof Node\Stmt\Throw_) {
+			return true;
+		} elseif ($lastStatement instanceof Node\Stmt\Expression && $this->isCallToFunctionThatThrows($lastStatement->expr)) {
+			return true;
+		} elseif ($lastStatement instanceof Node\Stmt\If_) {
+			return $this->allIfBranchesThrow($lastStatement);
+		} elseif ($lastStatement instanceof Node\Stmt\Switch_) {
+			return $this->allSwitchCasesThrow($lastStatement);
+		} elseif ($lastStatement instanceof Node\Stmt\TryCatch) {
+			return $this->allTryCatchBranchesThrow($lastStatement);
+		} else {
+			return false;
+		}
+	}
+
+	/**
+	 * Check if all branches of an if statement throw
+	 *
+	 * @param Node\Stmt\If_ $ifStatement Instance of If_
+	 *
+	 * @return bool
+	 */
+	private function allIfBranchesThrow(Node\Stmt\If_ $ifStatement): bool {
+		if ($this->isConstantTrue($ifStatement->cond)) {
+			return $this->statementsAllThrow($ifStatement->stmts);
+		}
+		if (!$ifStatement->else) {
+			return false;
+		}
+		if (!$this->statementsAllThrow($ifStatement->stmts)) {
+			return false;
+		}
+		if (!$this->statementsAllThrow($ifStatement->else->stmts)) {
+			return false;
+		}
+		if ($ifStatement->elseifs) {
+			foreach ($ifStatement->elseifs as $elseIf) {
+				if (!$this->statementsAllThrow($elseIf->stmts)) {
+					return false;
+				}
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Check if all cases of a switch statement throw
+	 *
+	 * @param Node\Stmt\Switch_ $switchStatement Instance of Switch_
+	 *
+	 * @return bool
+	 */
+	private function allSwitchCasesThrow(Node\Stmt\Switch_ $switchStatement): bool {
+		$hasDefault = false;
+		foreach ($switchStatement->cases as $case) {
+			if ($case->cond === null) {
+				$hasDefault = true;
+			}
+			$stmts = $case->stmts;
+			while (($last = end($stmts)) instanceof Node\Stmt\Break_ || $last instanceof Node\Stmt\Nop) {
+				$stmts = array_slice($stmts, 0, -1);
+			}
+			if ($stmts && !$this->statementsAllThrow($stmts)) {
+				return false;
+			}
+		}
+		return $hasDefault;
+	}
+
+	/**
+	 * Check if all branches of a try-catch statement throw
+	 *
+	 * @param Node\Stmt\TryCatch $tryCatch Instance of TryCatch
+	 *
+	 * @return bool
+	 */
+	private function allTryCatchBranchesThrow(Node\Stmt\TryCatch $tryCatch): bool {
+		// If finally block throws, it overrides try/catch
+		if ($tryCatch->finally && $this->statementsAllThrow($tryCatch->finally->stmts)) {
+			return true;
+		}
+
+		// Otherwise, both try and all catch blocks must throw
+		if (!$this->statementsAllThrow($tryCatch->stmts)) {
+			return false;
+		}
+		foreach ($tryCatch->catches as $catch) {
+			if (!$this->statementsAllThrow($catch->stmts)) {
+				return false;
+			}
+		}
+		return true;
 	}
 }

--- a/src/Checks/ReturnCheck.php
+++ b/src/Checks/ReturnCheck.php
@@ -205,6 +205,8 @@ class ReturnCheck extends BaseCheck {
 			return true;
 		} elseif ($lastStatement instanceof Node\Stmt\Expression && $lastStatement->expr instanceof Node\Expr\Exit_) {
 			return true;
+		} elseif ($lastStatement instanceof Node\Stmt\Expression && $this->isCallToFunctionThatThrows($lastStatement->expr)) {
+			return true;
 		} elseif ($lastStatement instanceof Node\Stmt\If_) {
 			return $this->allIfBranchesReturnOrThrow($lastStatement);
 		} elseif ($lastStatement instanceof Node\Stmt\Switch_) {
@@ -370,5 +372,35 @@ class ReturnCheck extends BaseCheck {
 
 	private function doWhileLoopReturnsOrThrows(Node\Stmt\Do_ $doWhileLoop): bool {
 		return $this->statementsAllReturnOrThrow($doWhileLoop->stmts);
+	}
+
+	/**
+	 * Check if an expression is a call to a function that never returns
+	 *
+	 * @param Node\Expr $expr The expression to check
+	 *
+	 * @return bool
+	 */
+	private function isCallToFunctionThatThrows(Node\Expr $expr): bool {
+		if ($expr instanceof Node\Expr\FuncCall) {
+			$name = $expr->name;
+			if ($name instanceof Node\Name) {
+				$function = $this->symbolTable->getAbstractedFunction(strval($name));
+				if ($function) {
+					// Check if the function body always throws/returns
+					if ($function instanceof \BambooHR\Guardrail\Abstractions\FunctionAbstraction) {
+						// FunctionAbstraction wraps a Function_ node, we need to check if it always throws
+						// We can use reflection to get the function property
+						$reflection = new \ReflectionClass($function);
+						$property = $reflection->getProperty('function');
+						$functionNode = $property->getValue($function);
+						if ($functionNode instanceof Node\Stmt\Function_) {
+							return $this->allPathsReturnOrThrow($functionNode);
+						}
+					}
+				}
+			}
+		}
+		return false;
 	}
 }

--- a/src/Checks/ReturnCheck.php
+++ b/src/Checks/ReturnCheck.php
@@ -141,7 +141,7 @@ class ReturnCheck extends BaseCheck {
 		}
 
 		if ($returnType && !$this->returnTypeAllowsNoReturn($returnType)) {
-			if (!$this->allPathsReturnOrThrow($node)) {
+			if (!$this->allPathsReturnOrThrow($node, false)) {
 				$functionName = $this->getFunctionName($node, $inside);
 				$this->emitError(
 					$fileName,
@@ -179,12 +179,12 @@ class ReturnCheck extends BaseCheck {
 	 *
 	 * @return bool
 	 */
-	private function allPathsReturnOrThrow(Node\FunctionLike $func): bool {
+	private function allPathsReturnOrThrow(Node\FunctionLike $func, $throwOnly): bool {
 		$stmts = $func->getStmts();
 		if (!$stmts) {
 			return false;
 		}
-		return $this->statementsAllReturnOrThrow($stmts, false);
+		return $this->statementsAllReturnOrThrow($stmts, $throwOnly);
 	}
 
 	/**
@@ -211,9 +211,9 @@ class ReturnCheck extends BaseCheck {
 		} elseif ($lastStatement instanceof Node\Stmt\If_) {
 			return $this->allIfBranchesReturnOrThrow($lastStatement, $throwOnly);
 		} elseif ($lastStatement instanceof Node\Stmt\Switch_) {
-			return $this->allTryCatchBranchesReturnOrThrow($lastStatement, $throwOnly);
+			return $this->allSwitchCasesReturnOrThrow($lastStatement, $throwOnly);
 		} elseif ($lastStatement instanceof Node\Stmt\TryCatch) {
-			return $this->checkTryCatchBranches($lastStatement, $throwOnly);
+			return $this->allTryCatchBranchesReturnOrThrow($lastStatement, $throwOnly);
 		} elseif ($lastStatement instanceof Node\Stmt\While_) {
 			return $this->whileLoopReturnsOrThrows($lastStatement, $throwOnly);
 		} elseif ($lastStatement instanceof Node\Stmt\Do_) {
@@ -279,13 +279,12 @@ class ReturnCheck extends BaseCheck {
 	 *
 	 * @return bool
 	 */
-	private function allTryCatchBranchesReturnOrThrow(Node\Stmt\Switch_ $switchStatement, bool $throwOnly): bool {
+	private function allSwitchCasesReturnOrThrow(Node\Stmt\Switch_ $switchStatement, bool $throwOnly): bool {
 		$hasDefault = false;
 		foreach ($switchStatement->cases as $case) {
 			if ($case->cond === null) {
 				$hasDefault = true;
 			}
-
 			$stmts = $case->stmts;
 			while (($last = end($stmts)) instanceof Node\Stmt\Break_ || $last instanceof Node\Stmt\Nop) {
 				$stmts = array_slice($stmts, 0, -1);
@@ -318,18 +317,19 @@ class ReturnCheck extends BaseCheck {
 
 
 	/**
-	 * Unified method to check if try-catch branches meet termination criteria
+	 * Check if all branches of a try-catch statement either return or throw (with options for throws only)
 	 *
 	 * @param Node\Stmt\TryCatch $tryCatch  Instance of TryCatch
 	 * @param bool               $throwOnly If true, only throw counts; if false, return or throw counts
 	 *
 	 * @return bool
 	 */
-	private function checkTryCatchBranches(Node\Stmt\TryCatch $tryCatch, bool $throwOnly): bool {
+	private function allTryCatchBranchesReturnOrThrow(Node\Stmt\TryCatch $tryCatch, bool $throwOnly): bool {
 		if ($tryCatch->finally && $this->statementsAllReturnOrThrow($tryCatch->finally->stmts, $throwOnly)) {
 			return true;
 		}
 
+		// Otherwise, both try and all catch blocks must return or throw
 		if (!$this->statementsAllReturnOrThrow($tryCatch->stmts, $throwOnly)) {
 			return false;
 		}
@@ -339,7 +339,6 @@ class ReturnCheck extends BaseCheck {
 				return false;
 			}
 		}
-
 		return true;
 	}
 
@@ -412,7 +411,7 @@ class ReturnCheck extends BaseCheck {
 		}
 
 		$functionNode = $this->getFunctionNodeFromAbstraction($function);
-		return $functionNode && $this->allPathsThrow($functionNode);
+		return $functionNode && $this->allPathsReturnOrThrow($functionNode, true);
 	}
 
 	/**
@@ -441,7 +440,7 @@ class ReturnCheck extends BaseCheck {
 			);
 			if ($method instanceof \BambooHR\Guardrail\Abstractions\ClassMethod) {
 				$methodNode = $this->getMethodNodeFromAbstraction($method);
-				if ($methodNode && $this->allPathsThrow($methodNode)) {
+				if ($methodNode && $this->allPathsReturnOrThrow($methodNode, true)) {
 					$allThrow = true;
 				}
 			}
@@ -472,22 +471,7 @@ class ReturnCheck extends BaseCheck {
 		}
 
 		$methodNode = $this->getMethodNodeFromAbstraction($method);
-		return $methodNode && $this->allPathsThrow($methodNode);
-	}
-
-	/**
-	 * Check if all code paths in a function throw an exception (not return)
-	 *
-	 * @param Node\FunctionLike $func The function to check
-	 *
-	 * @return bool
-	 */
-	private function allPathsThrow(Node\FunctionLike $func): bool {
-		$stmts = $func->getStmts();
-		if (!$stmts) {
-			return false;
-		}
-		return $this->statementsAllReturnOrThrow($stmts, true);
+		return $methodNode && $this->allPathsReturnOrThrow($methodNode, true);
 	}
 
 	/**

--- a/src/Checks/ReturnCheck.php
+++ b/src/Checks/ReturnCheck.php
@@ -223,6 +223,35 @@ class ReturnCheck extends BaseCheck {
 	}
 
 	/**
+	 * Helper method to check statements based on throw-only or return-or-throw criteria
+	 *
+	 * @param array $stmts     List of statements
+	 * @param bool  $throwOnly If true, only throw counts; if false, return or throw counts
+	 *
+	 * @return bool
+	 */
+	private function checkStatements(array $stmts, bool $throwOnly): bool {
+		if ($throwOnly) {
+			return $this->statementsAllThrow($stmts);
+		}
+		return $this->statementsAllReturnOrThrow($stmts);
+	}
+
+	/**
+	 * Remove trailing break and nop statements from a list
+	 *
+	 * @param array $stmts The statements
+	 *
+	 * @return array
+	 */
+	private function removeTrailingBreaksAndNops(array $stmts): array {
+		while (($last = end($stmts)) instanceof Node\Stmt\Break_ || $last instanceof Node\Stmt\Nop) {
+			$stmts = array_slice($stmts, 0, -1);
+		}
+		return $stmts;
+	}
+
+	/**
 	 * Get the last non-Nop statement from a list of statements
 	 *
 	 * @param array $stmts The statements
@@ -337,53 +366,94 @@ class ReturnCheck extends BaseCheck {
 	 */
 	private function isCallToFunctionThatThrows(Node\Expr $expr): bool {
 		if ($expr instanceof Node\Expr\FuncCall) {
-			$name = $expr->name;
-			if ($name instanceof Node\Name) {
-				$function = $this->symbolTable->getAbstractedFunction(strval($name));
-				if ($function) {
-					// Check if the function body always throws (not just returns)
-					if ($function instanceof \BambooHR\Guardrail\Abstractions\FunctionAbstraction) {
-						// FunctionAbstraction wraps a Function_ node, we need to check if it always throws
-						// We can use reflection to get the function property
-						$reflection = new \ReflectionClass($function);
-						$property = $reflection->getProperty('function');
-						$functionNode = $property->getValue($function);
-						if ($functionNode instanceof Node\Stmt\Function_) {
-							return $this->allPathsThrow($functionNode);
-						}
-					}
-				}
-			}
-		} elseif ($expr instanceof Node\Expr\MethodCall && $expr->name instanceof Node\Identifier) {
-			// Handle instance method calls
-			$type = $expr->var->getAttribute(\BambooHR\Guardrail\TypeComparer::INFERRED_TYPE_ATTR);
-			if ($type) {
-				$allThrow = false;
-				TypeComparer::forEachType($type, function ($typeNode) use ($expr, &$allThrow) {
-					$method = \BambooHR\Guardrail\Util::findAbstractedMethod(strval($typeNode), $expr->name, $this->symbolTable);
-					if ($method && $method instanceof \BambooHR\Guardrail\Abstractions\ClassMethod) {
-						$methodNode = $this->extractMethodNode($method);
-						if ($methodNode && $this->allPathsThrow($methodNode)) {
-							$allThrow = true;
-						}
-					}
-				});
-				return $allThrow;
-			}
-		} elseif ($expr instanceof Node\Expr\StaticCall && $expr->name instanceof Node\Identifier) {
-			// Handle static method calls
-			if ($expr->class instanceof Node\Name) {
-				$className = strval($expr->class);
-				$method = \BambooHR\Guardrail\Util::findAbstractedMethod($className, $expr->name, $this->symbolTable);
-				if ($method && $method instanceof \BambooHR\Guardrail\Abstractions\ClassMethod) {
-					$methodNode = $this->extractMethodNode($method);
-					if ($methodNode) {
-						return $this->allPathsThrow($methodNode);
-					}
-				}
-			}
+			return $this->isFunctionCallThatThrows($expr);
+		} elseif ($expr instanceof Node\Expr\MethodCall) {
+			return $this->isMethodCallThatThrows($expr);
+		} elseif ($expr instanceof Node\Expr\StaticCall) {
+			return $this->isStaticCallThatThrows($expr);
 		}
 		return false;
+	}
+
+	/**
+	 * Check if a function call always throws
+	 *
+	 * @param Node\Expr\FuncCall $funcCall The function call to check
+	 *
+	 * @return bool
+	 */
+	private function isFunctionCallThatThrows(Node\Expr\FuncCall $funcCall): bool {
+		if (!$funcCall->name instanceof Node\Name) {
+			return false;
+		}
+
+		$function = $this->symbolTable->getAbstractedFunction(strval($funcCall->name));
+		if (!$function instanceof \BambooHR\Guardrail\Abstractions\FunctionAbstraction) {
+			return false;
+		}
+
+		$functionNode = $this->getFunctionNodeFromAbstraction($function);
+		return $functionNode && $this->allPathsThrow($functionNode);
+	}
+
+	/**
+	 * Check if an instance method call always throws
+	 *
+	 * @param Node\Expr\MethodCall $methodCall The method call to check
+	 *
+	 * @return bool
+	 */
+	private function isMethodCallThatThrows(Node\Expr\MethodCall $methodCall): bool {
+		if (!$methodCall->name instanceof Node\Identifier) {
+			return false;
+		}
+
+		$type = $methodCall->var->getAttribute(TypeComparer::INFERRED_TYPE_ATTR);
+		if (!$type) {
+			return false;
+		}
+
+		$allThrow = false;
+		TypeComparer::forEachType($type, function ($typeNode) use ($methodCall, &$allThrow) {
+			$method = \BambooHR\Guardrail\Util::findAbstractedMethod(
+				strval($typeNode),
+				$methodCall->name,
+				$this->symbolTable
+			);
+			if ($method instanceof \BambooHR\Guardrail\Abstractions\ClassMethod) {
+				$methodNode = $this->getMethodNodeFromAbstraction($method);
+				if ($methodNode && $this->allPathsThrow($methodNode)) {
+					$allThrow = true;
+				}
+			}
+		});
+		return $allThrow;
+	}
+
+	/**
+	 * Check if a static method call always throws
+	 *
+	 * @param Node\Expr\StaticCall $staticCall The static call to check
+	 *
+	 * @return bool
+	 */
+	private function isStaticCallThatThrows(Node\Expr\StaticCall $staticCall): bool {
+		if (!$staticCall->name instanceof Node\Identifier || !$staticCall->class instanceof Node\Name) {
+			return false;
+		}
+
+		$method = \BambooHR\Guardrail\Util::findAbstractedMethod(
+			strval($staticCall->class),
+			$staticCall->name,
+			$this->symbolTable
+		);
+
+		if (!$method instanceof \BambooHR\Guardrail\Abstractions\ClassMethod) {
+			return false;
+		}
+
+		$methodNode = $this->getMethodNodeFromAbstraction($method);
+		return $methodNode && $this->allPathsThrow($methodNode);
 	}
 
 	/**
@@ -471,40 +541,29 @@ class ReturnCheck extends BaseCheck {
 	 */
 	private function checkIfBranches(Node\Stmt\If_ $ifStatement, bool $throwOnly): bool {
 		if ($this->isConstantTrue($ifStatement->cond)) {
-			return $throwOnly ? $this->statementsAllThrow($ifStatement->stmts) : $this->statementsAllReturnOrThrow($ifStatement->stmts);
+			return $this->checkStatements($ifStatement->stmts, $throwOnly);
 		}
+
 		if (!$ifStatement->else) {
 			return false;
 		}
-		if ($throwOnly) {
-			if (!$this->statementsAllThrow($ifStatement->stmts)) {
-				return false;
-			}
-			if (!$this->statementsAllThrow($ifStatement->else->stmts)) {
-				return false;
-			}
-			if ($ifStatement->elseifs) {
-				foreach ($ifStatement->elseifs as $elseIf) {
-					if (!$this->statementsAllThrow($elseIf->stmts)) {
-						return false;
-					}
-				}
-			}
-		} else {
-			if (!$this->statementsAllReturnOrThrow($ifStatement->stmts)) {
-				return false;
-			}
-			if (!$this->statementsAllReturnOrThrow($ifStatement->else->stmts)) {
-				return false;
-			}
-			if ($ifStatement->elseifs) {
-				foreach ($ifStatement->elseifs as $elseIf) {
-					if (!$this->statementsAllReturnOrThrow($elseIf->stmts)) {
-						return false;
-					}
+
+		if (!$this->checkStatements($ifStatement->stmts, $throwOnly)) {
+			return false;
+		}
+
+		if (!$this->checkStatements($ifStatement->else->stmts, $throwOnly)) {
+			return false;
+		}
+
+		if ($ifStatement->elseifs) {
+			foreach ($ifStatement->elseifs as $elseIf) {
+				if (!$this->checkStatements($elseIf->stmts, $throwOnly)) {
+					return false;
 				}
 			}
 		}
+
 		return true;
 	}
 
@@ -522,15 +581,10 @@ class ReturnCheck extends BaseCheck {
 			if ($case->cond === null) {
 				$hasDefault = true;
 			}
-			$stmts = $case->stmts;
-			while (($last = end($stmts)) instanceof Node\Stmt\Break_ || $last instanceof Node\Stmt\Nop) {
-				$stmts = array_slice($stmts, 0, -1);
-			}
-			if ($stmts) {
-				$allTerminate = $throwOnly ? $this->statementsAllThrow($stmts) : $this->statementsAllReturnOrThrow($stmts);
-				if (!$allTerminate) {
-					return false;
-				}
+
+			$stmts = $this->removeTrailingBreaksAndNops($case->stmts);
+			if ($stmts && !$this->checkStatements($stmts, $throwOnly)) {
+				return false;
 			}
 		}
 		return $hasDefault;
@@ -545,34 +599,45 @@ class ReturnCheck extends BaseCheck {
 	 * @return bool
 	 */
 	private function checkTryCatchBranches(Node\Stmt\TryCatch $tryCatch, bool $throwOnly): bool {
-		if ($tryCatch->finally) {
-			$finallyTerminates = $throwOnly ? $this->statementsAllThrow($tryCatch->finally->stmts) : $this->statementsAllReturnOrThrow($tryCatch->finally->stmts);
-			if ($finallyTerminates) {
-				return true;
-			}
+		if ($tryCatch->finally && $this->checkStatements($tryCatch->finally->stmts, $throwOnly)) {
+			return true;
 		}
 
-		$tryTerminates = $throwOnly ? $this->statementsAllThrow($tryCatch->stmts) : $this->statementsAllReturnOrThrow($tryCatch->stmts);
-		if (!$tryTerminates) {
+		if (!$this->checkStatements($tryCatch->stmts, $throwOnly)) {
 			return false;
 		}
+
 		foreach ($tryCatch->catches as $catch) {
-			$catchTerminates = $throwOnly ? $this->statementsAllThrow($catch->stmts) : $this->statementsAllReturnOrThrow($catch->stmts);
-			if (!$catchTerminates) {
+			if (!$this->checkStatements($catch->stmts, $throwOnly)) {
 				return false;
 			}
 		}
+
 		return true;
 	}
 
 	/**
-	 * Extract method node from a ClassMethod abstraction
+	 * Get the underlying function node from a FunctionAbstraction
+	 *
+	 * @param \BambooHR\Guardrail\Abstractions\FunctionAbstraction $function
+	 *
+	 * @return Node\Stmt\Function_|null
+	 */
+	private function getFunctionNodeFromAbstraction(\BambooHR\Guardrail\Abstractions\FunctionAbstraction $function): ?Node\Stmt\Function_ {
+		$reflection = new \ReflectionClass($function);
+		$property = $reflection->getProperty('function');
+		$functionNode = $property->getValue($function);
+		return $functionNode instanceof Node\Stmt\Function_ ? $functionNode : null;
+	}
+
+	/**
+	 * Get the underlying method node from a ClassMethod abstraction
 	 *
 	 * @param \BambooHR\Guardrail\Abstractions\ClassMethod $method
 	 *
 	 * @return Node\Stmt\ClassMethod|null
 	 */
-	private function extractMethodNode(\BambooHR\Guardrail\Abstractions\ClassMethod $method): ?Node\Stmt\ClassMethod {
+	private function getMethodNodeFromAbstraction(\BambooHR\Guardrail\Abstractions\ClassMethod $method): ?Node\Stmt\ClassMethod {
 		$reflection = new \ReflectionClass($method);
 		$property = $reflection->getProperty('method');
 		$methodNode = $property->getValue($method);

--- a/src/Checks/ReturnCheck.php
+++ b/src/Checks/ReturnCheck.php
@@ -465,7 +465,7 @@ class ReturnCheck extends BaseCheck {
 	 * Unified method to check if branches meet termination criteria
 	 *
 	 * @param Node\Stmt\If_ $ifStatement Instance of If_
-	 * @param bool           $throwOnly    If true, only throw counts; if false, return or throw counts
+	 * @param bool          $throwOnly   If true, only throw counts; if false, return or throw counts
 	 *
 	 * @return bool
 	 */
@@ -498,7 +498,7 @@ class ReturnCheck extends BaseCheck {
 	 * Unified method to check if switch cases meet termination criteria
 	 *
 	 * @param Node\Stmt\Switch_ $switchStatement Instance of Switch_
-	 * @param bool               $throwOnly        If true, only throw counts; if false, return or throw counts
+	 * @param bool              $throwOnly       If true, only throw counts; if false, return or throw counts
 	 *
 	 * @return bool
 	 */
@@ -525,7 +525,7 @@ class ReturnCheck extends BaseCheck {
 	 * Unified method to check if try-catch branches meet termination criteria
 	 *
 	 * @param Node\Stmt\TryCatch $tryCatch  Instance of TryCatch
-	 * @param bool                $throwOnly If true, only throw counts; if false, return or throw counts
+	 * @param bool               $throwOnly If true, only throw counts; if false, return or throw counts
 	 *
 	 * @return bool
 	 */

--- a/src/Checks/ReturnCheck.php
+++ b/src/Checks/ReturnCheck.php
@@ -470,24 +470,38 @@ class ReturnCheck extends BaseCheck {
 	 * @return bool
 	 */
 	private function checkIfBranches(Node\Stmt\If_ $ifStatement, bool $throwOnly): bool {
-		$checker = $throwOnly ? [$this, 'statementsAllThrow'] : [$this, 'statementsAllReturnOrThrow'];
-
 		if ($this->isConstantTrue($ifStatement->cond)) {
-			return $checker($ifStatement->stmts);
+			return $throwOnly ? $this->statementsAllThrow($ifStatement->stmts) : $this->statementsAllReturnOrThrow($ifStatement->stmts);
 		}
 		if (!$ifStatement->else) {
 			return false;
 		}
-		if (!$checker($ifStatement->stmts)) {
-			return false;
-		}
-		if (!$checker($ifStatement->else->stmts)) {
-			return false;
-		}
-		if ($ifStatement->elseifs) {
-			foreach ($ifStatement->elseifs as $elseIf) {
-				if (!$checker($elseIf->stmts)) {
-					return false;
+		if ($throwOnly) {
+			if (!$this->statementsAllThrow($ifStatement->stmts)) {
+				return false;
+			}
+			if (!$this->statementsAllThrow($ifStatement->else->stmts)) {
+				return false;
+			}
+			if ($ifStatement->elseifs) {
+				foreach ($ifStatement->elseifs as $elseIf) {
+					if (!$this->statementsAllThrow($elseIf->stmts)) {
+						return false;
+					}
+				}
+			}
+		} else {
+			if (!$this->statementsAllReturnOrThrow($ifStatement->stmts)) {
+				return false;
+			}
+			if (!$this->statementsAllReturnOrThrow($ifStatement->else->stmts)) {
+				return false;
+			}
+			if ($ifStatement->elseifs) {
+				foreach ($ifStatement->elseifs as $elseIf) {
+					if (!$this->statementsAllReturnOrThrow($elseIf->stmts)) {
+						return false;
+					}
 				}
 			}
 		}
@@ -503,8 +517,6 @@ class ReturnCheck extends BaseCheck {
 	 * @return bool
 	 */
 	private function checkSwitchCases(Node\Stmt\Switch_ $switchStatement, bool $throwOnly): bool {
-		$checker = $throwOnly ? [$this, 'statementsAllThrow'] : [$this, 'statementsAllReturnOrThrow'];
-
 		$hasDefault = false;
 		foreach ($switchStatement->cases as $case) {
 			if ($case->cond === null) {
@@ -514,8 +526,11 @@ class ReturnCheck extends BaseCheck {
 			while (($last = end($stmts)) instanceof Node\Stmt\Break_ || $last instanceof Node\Stmt\Nop) {
 				$stmts = array_slice($stmts, 0, -1);
 			}
-			if ($stmts && !$checker($stmts)) {
-				return false;
+			if ($stmts) {
+				$allTerminate = $throwOnly ? $this->statementsAllThrow($stmts) : $this->statementsAllReturnOrThrow($stmts);
+				if (!$allTerminate) {
+					return false;
+				}
 			}
 		}
 		return $hasDefault;
@@ -530,17 +545,20 @@ class ReturnCheck extends BaseCheck {
 	 * @return bool
 	 */
 	private function checkTryCatchBranches(Node\Stmt\TryCatch $tryCatch, bool $throwOnly): bool {
-		$checker = $throwOnly ? [$this, 'statementsAllThrow'] : [$this, 'statementsAllReturnOrThrow'];
-
-		if ($tryCatch->finally && $checker($tryCatch->finally->stmts)) {
-			return true;
+		if ($tryCatch->finally) {
+			$finallyTerminates = $throwOnly ? $this->statementsAllThrow($tryCatch->finally->stmts) : $this->statementsAllReturnOrThrow($tryCatch->finally->stmts);
+			if ($finallyTerminates) {
+				return true;
+			}
 		}
 
-		if (!$checker($tryCatch->stmts)) {
+		$tryTerminates = $throwOnly ? $this->statementsAllThrow($tryCatch->stmts) : $this->statementsAllReturnOrThrow($tryCatch->stmts);
+		if (!$tryTerminates) {
 			return false;
 		}
 		foreach ($tryCatch->catches as $catch) {
-			if (!$checker($catch->stmts)) {
+			$catchTerminates = $throwOnly ? $this->statementsAllThrow($catch->stmts) : $this->statementsAllReturnOrThrow($catch->stmts);
+			if (!$catchTerminates) {
 				return false;
 			}
 		}

--- a/src/Checks/ReturnCheck.php
+++ b/src/Checks/ReturnCheck.php
@@ -184,17 +184,18 @@ class ReturnCheck extends BaseCheck {
 		if (!$stmts) {
 			return false;
 		}
-		return $this->statementsAllReturnOrThrow($stmts);
+		return $this->statementsAllReturnOrThrow($stmts, false);
 	}
 
 	/**
 	 * Check if all code paths in a list of statements either return or throw
 	 *
-	 * @param array $stmts List of statements
+	 * @param array $stmts     List of statements
+	 * @param bool  $throwOnly If true, only throw counts; if false, return or throw counts
 	 *
 	 * @return bool
 	 */
-	private function statementsAllReturnOrThrow(array $stmts): bool {
+	private function statementsAllReturnOrThrow(array $stmts, bool $throwOnly): bool {
 		$lastStatement = $this->getLastNonNopStatement($stmts);
 
 		if (!$lastStatement) {
@@ -208,15 +209,18 @@ class ReturnCheck extends BaseCheck {
 		} elseif ($lastStatement instanceof Node\Stmt\Expression && $this->isCallToFunctionThatThrows($lastStatement->expr)) {
 			return true;
 		} elseif ($lastStatement instanceof Node\Stmt\If_) {
-			return $this->checkIfBranches($lastStatement, false);
+			return $this->allIfBranchesReturnOrThrow($lastStatement, $throwOnly);
 		} elseif ($lastStatement instanceof Node\Stmt\Switch_) {
-			return $this->checkSwitchCases($lastStatement, false);
+			return $this->checkSwitchCases($lastStatement, $throwOnly);
 		} elseif ($lastStatement instanceof Node\Stmt\TryCatch) {
-			return $this->checkTryCatchBranches($lastStatement, false);
+			return $this->checkTryCatchBranches($lastStatement, $throwOnly);
 		} elseif ($lastStatement instanceof Node\Stmt\While_) {
-			return $this->whileLoopReturnsOrThrows($lastStatement);
+			if ($this->isConstantTrue($lastStatement->cond)) {
+				return $this->statementsAllReturnOrThrow($lastStatement->stmts, $throwOnly);
+			}
+			return false;
 		} elseif ($lastStatement instanceof Node\Stmt\Do_) {
-			return $this->doWhileLoopReturnsOrThrows($lastStatement);
+			return $this->statementsAllReturnOrThrow($lastStatement->stmts, $throwOnly);
 		} else {
 			return false;
 		}
@@ -234,7 +238,7 @@ class ReturnCheck extends BaseCheck {
 		if ($throwOnly) {
 			return $this->statementsAllThrow($stmts);
 		}
-		return $this->statementsAllReturnOrThrow($stmts);
+		return $this->statementsAllReturnOrThrow($stmts, false);
 	}
 
 	/**
@@ -269,14 +273,14 @@ class ReturnCheck extends BaseCheck {
 	}
 
 	/**
-	 * Unified method to check if branches meet termination criteria
+	 * Check if all branches of an if statement either return or throws (with options for throw only)
 	 *
 	 * @param Node\Stmt\If_ $ifStatement Instance of If_
 	 * @param bool          $throwOnly   If true, only throw counts; if false, return or throw counts
 	 *
 	 * @return bool
 	 */
-	private function checkIfBranches(Node\Stmt\If_ $ifStatement, bool $throwOnly): bool {
+	private function allIfBranchesReturnOrThrow(Node\Stmt\If_ $ifStatement, bool $throwOnly): bool {
 		if ($this->isConstantTrue($ifStatement->cond)) {
 			return $this->checkStatements($ifStatement->stmts, $throwOnly);
 		}
@@ -321,6 +325,7 @@ class ReturnCheck extends BaseCheck {
 		}
 		return $hasDefault;
 	}
+
 
 	/**
 	 * Unified method to check if try-catch branches meet termination criteria
@@ -391,17 +396,6 @@ class ReturnCheck extends BaseCheck {
 			return $name === 'true';
 		}
 		return false;
-	}
-
-	private function whileLoopReturnsOrThrows(Node\Stmt\While_ $whileLoop): bool {
-		if ($this->isConstantTrue($whileLoop->cond)) {
-			return $this->statementsAllReturnOrThrow($whileLoop->stmts);
-		}
-		return false;
-	}
-
-	private function doWhileLoopReturnsOrThrows(Node\Stmt\Do_ $doWhileLoop): bool {
-		return $this->statementsAllReturnOrThrow($doWhileLoop->stmts);
 	}
 
 	/**
@@ -535,7 +529,7 @@ class ReturnCheck extends BaseCheck {
 		} elseif ($lastStatement instanceof Node\Stmt\Expression && $this->isCallToFunctionThatThrows($lastStatement->expr)) {
 			return true;
 		} elseif ($lastStatement instanceof Node\Stmt\If_) {
-			return $this->checkIfBranches($lastStatement, true);
+			return $this->allIfBranchesReturnOrThrow($lastStatement, true);
 		} elseif ($lastStatement instanceof Node\Stmt\Switch_) {
 			return $this->checkSwitchCases($lastStatement, true);
 		} elseif ($lastStatement instanceof Node\Stmt\TryCatch) {

--- a/src/Checks/ReturnCheck.php
+++ b/src/Checks/ReturnCheck.php
@@ -208,11 +208,11 @@ class ReturnCheck extends BaseCheck {
 		} elseif ($lastStatement instanceof Node\Stmt\Expression && $this->isCallToFunctionThatThrows($lastStatement->expr)) {
 			return true;
 		} elseif ($lastStatement instanceof Node\Stmt\If_) {
-			return $this->allIfBranchesReturnOrThrow($lastStatement);
+			return $this->checkIfBranches($lastStatement, false);
 		} elseif ($lastStatement instanceof Node\Stmt\Switch_) {
-			return $this->allSwitchCasesReturnOrThrow($lastStatement);
+			return $this->checkSwitchCases($lastStatement, false);
 		} elseif ($lastStatement instanceof Node\Stmt\TryCatch) {
-			return $this->allTryCatchBranchesReturnOrThrow($lastStatement);
+			return $this->checkTryCatchBranches($lastStatement, false);
 		} elseif ($lastStatement instanceof Node\Stmt\While_) {
 			return $this->whileLoopReturnsOrThrows($lastStatement);
 		} elseif ($lastStatement instanceof Node\Stmt\Do_) {
@@ -269,25 +269,83 @@ class ReturnCheck extends BaseCheck {
 	}
 
 	/**
-	 * Check if all branches of an if statement either return or throw
+	 * Unified method to check if branches meet termination criteria
 	 *
 	 * @param Node\Stmt\If_ $ifStatement Instance of If_
+	 * @param bool          $throwOnly   If true, only throw counts; if false, return or throw counts
 	 *
 	 * @return bool
 	 */
-	private function allIfBranchesReturnOrThrow(Node\Stmt\If_ $ifStatement): bool {
-		return $this->checkIfBranches($ifStatement, false);
+	private function checkIfBranches(Node\Stmt\If_ $ifStatement, bool $throwOnly): bool {
+		if ($this->isConstantTrue($ifStatement->cond)) {
+			return $this->checkStatements($ifStatement->stmts, $throwOnly);
+		}
+		if (!$ifStatement->else) {
+			return false;
+		}
+		if (!$this->checkStatements($ifStatement->stmts, $throwOnly)) {
+			return false;
+		}
+		if (!$this->checkStatements($ifStatement->else->stmts, $throwOnly)) {
+			return false;
+		}
+		if ($ifStatement->elseifs) {
+			foreach ($ifStatement->elseifs as $elseIf) {
+				if (!$this->checkStatements($elseIf->stmts, $throwOnly)) {
+					return false;
+				}
+			}
+		}
+		return true;
 	}
 
 	/**
-	 * Check if all cases of a switch statement either return or throw
+	 * Unified method to check if switch cases meet termination criteria
 	 *
 	 * @param Node\Stmt\Switch_ $switchStatement Instance of Switch_
+	 * @param bool              $throwOnly       If true, only throw counts; if false, return or throw counts
 	 *
 	 * @return bool
 	 */
-	private function allSwitchCasesReturnOrThrow(Node\Stmt\Switch_ $switchStatement): bool {
-		return $this->checkSwitchCases($switchStatement, false);
+	private function checkSwitchCases(Node\Stmt\Switch_ $switchStatement, bool $throwOnly): bool {
+		$hasDefault = false;
+		foreach ($switchStatement->cases as $case) {
+			if ($case->cond === null) {
+				$hasDefault = true;
+			}
+
+			$stmts = $this->removeTrailingBreaksAndNops($case->stmts);
+			if ($stmts && !$this->checkStatements($stmts, $throwOnly)) {
+				return false;
+			}
+		}
+		return $hasDefault;
+	}
+
+	/**
+	 * Unified method to check if try-catch branches meet termination criteria
+	 *
+	 * @param Node\Stmt\TryCatch $tryCatch  Instance of TryCatch
+	 * @param bool               $throwOnly If true, only throw counts; if false, return or throw counts
+	 *
+	 * @return bool
+	 */
+	private function checkTryCatchBranches(Node\Stmt\TryCatch $tryCatch, bool $throwOnly): bool {
+		if ($tryCatch->finally && $this->checkStatements($tryCatch->finally->stmts, $throwOnly)) {
+			return true;
+		}
+
+		if (!$this->checkStatements($tryCatch->stmts, $throwOnly)) {
+			return false;
+		}
+
+		foreach ($tryCatch->catches as $catch) {
+			if (!$this->checkStatements($catch->stmts, $throwOnly)) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**
@@ -307,17 +365,6 @@ class ReturnCheck extends BaseCheck {
 			$functionName = "$class::" . strval($insideFunc->name);
 		}
 		return $functionName;
-	}
-
-	/**
-	 * Check if all branches of a try-catch statement either return or throw
-	 *
-	 * @param Node\Stmt\TryCatch $tryCatch Instance of TryCatch
-	 *
-	 * @return bool
-	 */
-	private function allTryCatchBranchesReturnOrThrow(Node\Stmt\TryCatch $tryCatch): bool {
-		return $this->checkTryCatchBranches($tryCatch, false);
 	}
 
 	/**
@@ -488,132 +535,14 @@ class ReturnCheck extends BaseCheck {
 		} elseif ($lastStatement instanceof Node\Stmt\Expression && $this->isCallToFunctionThatThrows($lastStatement->expr)) {
 			return true;
 		} elseif ($lastStatement instanceof Node\Stmt\If_) {
-			return $this->allIfBranchesThrow($lastStatement);
+			return $this->checkIfBranches($lastStatement, true);
 		} elseif ($lastStatement instanceof Node\Stmt\Switch_) {
-			return $this->allSwitchCasesThrow($lastStatement);
+			return $this->checkSwitchCases($lastStatement, true);
 		} elseif ($lastStatement instanceof Node\Stmt\TryCatch) {
-			return $this->allTryCatchBranchesThrow($lastStatement);
+			return $this->checkTryCatchBranches($lastStatement, true);
 		} else {
 			return false;
 		}
-	}
-
-	/**
-	 * Check if all branches of an if statement throw
-	 *
-	 * @param Node\Stmt\If_ $ifStatement Instance of If_
-	 *
-	 * @return bool
-	 */
-	private function allIfBranchesThrow(Node\Stmt\If_ $ifStatement): bool {
-		return $this->checkIfBranches($ifStatement, true);
-	}
-
-	/**
-	 * Check if all cases of a switch statement throw
-	 *
-	 * @param Node\Stmt\Switch_ $switchStatement Instance of Switch_
-	 *
-	 * @return bool
-	 */
-	private function allSwitchCasesThrow(Node\Stmt\Switch_ $switchStatement): bool {
-		return $this->checkSwitchCases($switchStatement, true);
-	}
-
-	/**
-	 * Check if all branches of a try-catch statement throw
-	 *
-	 * @param Node\Stmt\TryCatch $tryCatch Instance of TryCatch
-	 *
-	 * @return bool
-	 */
-	private function allTryCatchBranchesThrow(Node\Stmt\TryCatch $tryCatch): bool {
-		return $this->checkTryCatchBranches($tryCatch, true);
-	}
-
-	/**
-	 * Unified method to check if branches meet termination criteria
-	 *
-	 * @param Node\Stmt\If_ $ifStatement Instance of If_
-	 * @param bool          $throwOnly   If true, only throw counts; if false, return or throw counts
-	 *
-	 * @return bool
-	 */
-	private function checkIfBranches(Node\Stmt\If_ $ifStatement, bool $throwOnly): bool {
-		if ($this->isConstantTrue($ifStatement->cond)) {
-			return $this->checkStatements($ifStatement->stmts, $throwOnly);
-		}
-
-		if (!$ifStatement->else) {
-			return false;
-		}
-
-		if (!$this->checkStatements($ifStatement->stmts, $throwOnly)) {
-			return false;
-		}
-
-		if (!$this->checkStatements($ifStatement->else->stmts, $throwOnly)) {
-			return false;
-		}
-
-		if ($ifStatement->elseifs) {
-			foreach ($ifStatement->elseifs as $elseIf) {
-				if (!$this->checkStatements($elseIf->stmts, $throwOnly)) {
-					return false;
-				}
-			}
-		}
-
-		return true;
-	}
-
-	/**
-	 * Unified method to check if switch cases meet termination criteria
-	 *
-	 * @param Node\Stmt\Switch_ $switchStatement Instance of Switch_
-	 * @param bool              $throwOnly       If true, only throw counts; if false, return or throw counts
-	 *
-	 * @return bool
-	 */
-	private function checkSwitchCases(Node\Stmt\Switch_ $switchStatement, bool $throwOnly): bool {
-		$hasDefault = false;
-		foreach ($switchStatement->cases as $case) {
-			if ($case->cond === null) {
-				$hasDefault = true;
-			}
-
-			$stmts = $this->removeTrailingBreaksAndNops($case->stmts);
-			if ($stmts && !$this->checkStatements($stmts, $throwOnly)) {
-				return false;
-			}
-		}
-		return $hasDefault;
-	}
-
-	/**
-	 * Unified method to check if try-catch branches meet termination criteria
-	 *
-	 * @param Node\Stmt\TryCatch $tryCatch  Instance of TryCatch
-	 * @param bool               $throwOnly If true, only throw counts; if false, return or throw counts
-	 *
-	 * @return bool
-	 */
-	private function checkTryCatchBranches(Node\Stmt\TryCatch $tryCatch, bool $throwOnly): bool {
-		if ($tryCatch->finally && $this->checkStatements($tryCatch->finally->stmts, $throwOnly)) {
-			return true;
-		}
-
-		if (!$this->checkStatements($tryCatch->stmts, $throwOnly)) {
-			return false;
-		}
-
-		foreach ($tryCatch->catches as $catch) {
-			if (!$this->checkStatements($catch->stmts, $throwOnly)) {
-				return false;
-			}
-		}
-
-		return true;
 	}
 
 	/**

--- a/src/Checks/ReturnCheck.php
+++ b/src/Checks/ReturnCheck.php
@@ -201,11 +201,11 @@ class ReturnCheck extends BaseCheck {
 		if (!$lastStatement) {
 			return false;
 		} elseif ($lastStatement instanceof Node\Stmt\Return_) {
-			return true;
+			return !$throwOnly;
 		} elseif ($lastStatement instanceof Node\Stmt\Throw_) {
 			return true;
 		} elseif ($lastStatement instanceof Node\Stmt\Expression && $lastStatement->expr instanceof Node\Expr\Exit_) {
-			return true;
+			return !$throwOnly;
 		} elseif ($lastStatement instanceof Node\Stmt\Expression && $this->isCallToFunctionThatThrows($lastStatement->expr)) {
 			return true;
 		} elseif ($lastStatement instanceof Node\Stmt\If_) {
@@ -224,21 +224,6 @@ class ReturnCheck extends BaseCheck {
 		} else {
 			return false;
 		}
-	}
-
-	/**
-	 * Helper method to check statements based on throw-only or return-or-throw criteria
-	 *
-	 * @param array $stmts     List of statements
-	 * @param bool  $throwOnly If true, only throw counts; if false, return or throw counts
-	 *
-	 * @return bool
-	 */
-	private function checkStatements(array $stmts, bool $throwOnly): bool {
-		if ($throwOnly) {
-			return $this->statementsAllThrow($stmts);
-		}
-		return $this->statementsAllReturnOrThrow($stmts, false);
 	}
 
 	/**
@@ -282,20 +267,20 @@ class ReturnCheck extends BaseCheck {
 	 */
 	private function allIfBranchesReturnOrThrow(Node\Stmt\If_ $ifStatement, bool $throwOnly): bool {
 		if ($this->isConstantTrue($ifStatement->cond)) {
-			return $this->checkStatements($ifStatement->stmts, $throwOnly);
+			return $this->statementsAllReturnOrThrow($ifStatement->stmts, $throwOnly);
 		}
 		if (!$ifStatement->else) {
 			return false;
 		}
-		if (!$this->checkStatements($ifStatement->stmts, $throwOnly)) {
+		if (!$this->statementsAllReturnOrThrow($ifStatement->stmts, $throwOnly)) {
 			return false;
 		}
-		if (!$this->checkStatements($ifStatement->else->stmts, $throwOnly)) {
+		if (!$this->statementsAllReturnOrThrow($ifStatement->else->stmts, $throwOnly)) {
 			return false;
 		}
 		if ($ifStatement->elseifs) {
 			foreach ($ifStatement->elseifs as $elseIf) {
-				if (!$this->checkStatements($elseIf->stmts, $throwOnly)) {
+				if (!$this->statementsAllReturnOrThrow($elseIf->stmts, $throwOnly)) {
 					return false;
 				}
 			}
@@ -319,7 +304,7 @@ class ReturnCheck extends BaseCheck {
 			}
 
 			$stmts = $this->removeTrailingBreaksAndNops($case->stmts);
-			if ($stmts && !$this->checkStatements($stmts, $throwOnly)) {
+			if ($stmts && !$this->statementsAllReturnOrThrow($stmts, $throwOnly)) {
 				return false;
 			}
 		}
@@ -336,16 +321,16 @@ class ReturnCheck extends BaseCheck {
 	 * @return bool
 	 */
 	private function checkTryCatchBranches(Node\Stmt\TryCatch $tryCatch, bool $throwOnly): bool {
-		if ($tryCatch->finally && $this->checkStatements($tryCatch->finally->stmts, $throwOnly)) {
+		if ($tryCatch->finally && $this->statementsAllReturnOrThrow($tryCatch->finally->stmts, $throwOnly)) {
 			return true;
 		}
 
-		if (!$this->checkStatements($tryCatch->stmts, $throwOnly)) {
+		if (!$this->statementsAllReturnOrThrow($tryCatch->stmts, $throwOnly)) {
 			return false;
 		}
 
 		foreach ($tryCatch->catches as $catch) {
-			if (!$this->checkStatements($catch->stmts, $throwOnly)) {
+			if (!$this->statementsAllReturnOrThrow($catch->stmts, $throwOnly)) {
 				return false;
 			}
 		}
@@ -509,34 +494,7 @@ class ReturnCheck extends BaseCheck {
 		if (!$stmts) {
 			return false;
 		}
-		return $this->statementsAllThrow($stmts);
-	}
-
-	/**
-	 * Check if all code paths in a list of statements throw (not return)
-	 *
-	 * @param array $stmts List of statements
-	 *
-	 * @return bool
-	 */
-	private function statementsAllThrow(array $stmts): bool {
-		$lastStatement = $this->getLastNonNopStatement($stmts);
-
-		if (!$lastStatement) {
-			return false;
-		} elseif ($lastStatement instanceof Node\Stmt\Throw_) {
-			return true;
-		} elseif ($lastStatement instanceof Node\Stmt\Expression && $this->isCallToFunctionThatThrows($lastStatement->expr)) {
-			return true;
-		} elseif ($lastStatement instanceof Node\Stmt\If_) {
-			return $this->allIfBranchesReturnOrThrow($lastStatement, true);
-		} elseif ($lastStatement instanceof Node\Stmt\Switch_) {
-			return $this->checkSwitchCases($lastStatement, true);
-		} elseif ($lastStatement instanceof Node\Stmt\TryCatch) {
-			return $this->checkTryCatchBranches($lastStatement, true);
-		} else {
-			return false;
-		}
+		return $this->statementsAllReturnOrThrow($stmts, true);
 	}
 
 	/**

--- a/src/Checks/ReturnCheck.php
+++ b/src/Checks/ReturnCheck.php
@@ -211,33 +211,16 @@ class ReturnCheck extends BaseCheck {
 		} elseif ($lastStatement instanceof Node\Stmt\If_) {
 			return $this->allIfBranchesReturnOrThrow($lastStatement, $throwOnly);
 		} elseif ($lastStatement instanceof Node\Stmt\Switch_) {
-			return $this->checkSwitchCases($lastStatement, $throwOnly);
+			return $this->allTryCatchBranchesReturnOrThrow($lastStatement, $throwOnly);
 		} elseif ($lastStatement instanceof Node\Stmt\TryCatch) {
 			return $this->checkTryCatchBranches($lastStatement, $throwOnly);
 		} elseif ($lastStatement instanceof Node\Stmt\While_) {
-			if ($this->isConstantTrue($lastStatement->cond)) {
-				return $this->statementsAllReturnOrThrow($lastStatement->stmts, $throwOnly);
-			}
-			return false;
+			return $this->whileLoopReturnsOrThrows($lastStatement, $throwOnly);
 		} elseif ($lastStatement instanceof Node\Stmt\Do_) {
 			return $this->statementsAllReturnOrThrow($lastStatement->stmts, $throwOnly);
 		} else {
 			return false;
 		}
-	}
-
-	/**
-	 * Remove trailing break and nop statements from a list
-	 *
-	 * @param array $stmts The statements
-	 *
-	 * @return array
-	 */
-	private function removeTrailingBreaksAndNops(array $stmts): array {
-		while (($last = end($stmts)) instanceof Node\Stmt\Break_ || $last instanceof Node\Stmt\Nop) {
-			$stmts = array_slice($stmts, 0, -1);
-		}
-		return $stmts;
 	}
 
 	/**
@@ -289,26 +272,48 @@ class ReturnCheck extends BaseCheck {
 	}
 
 	/**
-	 * Unified method to check if switch cases meet termination criteria
+	 * Check if all cases of a switch statement either return or throw (with options for throw only)
 	 *
 	 * @param Node\Stmt\Switch_ $switchStatement Instance of Switch_
 	 * @param bool              $throwOnly       If true, only throw counts; if false, return or throw counts
 	 *
 	 * @return bool
 	 */
-	private function checkSwitchCases(Node\Stmt\Switch_ $switchStatement, bool $throwOnly): bool {
+	private function allTryCatchBranchesReturnOrThrow(Node\Stmt\Switch_ $switchStatement, bool $throwOnly): bool {
 		$hasDefault = false;
 		foreach ($switchStatement->cases as $case) {
 			if ($case->cond === null) {
 				$hasDefault = true;
 			}
 
-			$stmts = $this->removeTrailingBreaksAndNops($case->stmts);
+			$stmts = $case->stmts;
+			while (($last = end($stmts)) instanceof Node\Stmt\Break_ || $last instanceof Node\Stmt\Nop) {
+				$stmts = array_slice($stmts, 0, -1);
+			}
 			if ($stmts && !$this->statementsAllReturnOrThrow($stmts, $throwOnly)) {
 				return false;
 			}
 		}
 		return $hasDefault;
+	}
+
+	/**
+	 * @param Node\FunctionLike $insideFunc The method we're inside of
+	 * @param ?ClassLike        $inside     The class we're inside of (if any)
+	 *
+	 * @return string
+	 */
+	protected function getFunctionName(Node\FunctionLike $insideFunc, ?ClassLike $inside = null) {
+		$functionName = "";
+		if ($insideFunc instanceof Node\Stmt\Function_) {
+			$functionName = strval($insideFunc->name);
+		} elseif ($insideFunc instanceof Node\Expr\Closure || $insideFunc instanceof Node\Expr\ArrowFunction) {
+			$functionName = "anonymous function";
+		} elseif ($insideFunc instanceof Node\Stmt\ClassMethod) {
+			$class = isset($inside->namespacedName) ? strval($inside->namespacedName) : "";
+			$functionName = "$class::" . strval($insideFunc->name);
+		}
+		return $functionName;
 	}
 
 
@@ -339,25 +344,6 @@ class ReturnCheck extends BaseCheck {
 	}
 
 	/**
-	 * @param Node\FunctionLike $insideFunc The method we're inside of
-	 * @param ?ClassLike        $inside     The class we're inside of (if any)
-	 *
-	 * @return string
-	 */
-	protected function getFunctionName(Node\FunctionLike $insideFunc, ?ClassLike $inside = null) {
-		$functionName = "";
-		if ($insideFunc instanceof Node\Stmt\Function_) {
-			$functionName = strval($insideFunc->name);
-		} elseif ($insideFunc instanceof Node\Expr\Closure || $insideFunc instanceof Node\Expr\ArrowFunction) {
-			$functionName = "anonymous function";
-		} elseif ($insideFunc instanceof Node\Stmt\ClassMethod) {
-			$class = isset($inside->namespacedName) ? strval($inside->namespacedName) : "";
-			$functionName = "$class::" . strval($insideFunc->name);
-		}
-		return $functionName;
-	}
-
-	/**
 	 * Check if a return type allows a function to have no return statement
 	 *
 	 * @param Node\Identifier|Node\Name|Node\ComplexType|null $returnType
@@ -379,6 +365,13 @@ class ReturnCheck extends BaseCheck {
 		if ($expr instanceof Node\Expr\ConstFetch) {
 			$name = strtolower($expr->name->toString());
 			return $name === 'true';
+		}
+		return false;
+	}
+
+	private function whileLoopReturnsOrThrows(Node\Stmt\While_ $whileLoop, bool $throwOnly): bool {
+		if ($this->isConstantTrue($whileLoop->cond)) {
+			return $this->statementsAllReturnOrThrow($whileLoop->stmts, $throwOnly);
 		}
 		return false;
 	}

--- a/src/Checks/ReturnCheck.php
+++ b/src/Checks/ReturnCheck.php
@@ -380,6 +380,26 @@ class ReturnCheck extends BaseCheck {
 	}
 
 	/**
+	 * Returns true if the given function/method always exits via throw, exit, etc.
+	 *
+	 * Prefers the cached `always_throws` attribute (set at indexing time when the
+	 * function body has already been stripped). Falls back to walking the statements
+	 * when the body is still present (in-memory symbol tables, or the function
+	 * currently being analyzed).
+	 *
+	 * @param Node\FunctionLike $node The function/method node to check
+	 *
+	 * @return bool
+	 */
+	private function functionAlwaysThrows(Node\FunctionLike $node): bool {
+		$cached = $node->getAttribute('always_throws');
+		if ($cached !== null) {
+			return (bool)$cached;
+		}
+		return $this->allPathsReturnOrThrow($node, true);
+	}
+
+	/**
 	 * Check if an expression is a call to a function that never returns
 	 *
 	 * @param Node\Expr $expr The expression to check
@@ -415,7 +435,7 @@ class ReturnCheck extends BaseCheck {
 		}
 
 		$functionNode = $this->getFunctionNodeFromAbstraction($function);
-		return $functionNode && $this->allPathsReturnOrThrow($functionNode, true);
+		return $functionNode && $this->functionAlwaysThrows($functionNode);
 	}
 
 	/**
@@ -444,7 +464,7 @@ class ReturnCheck extends BaseCheck {
 			);
 			if ($method instanceof \BambooHR\Guardrail\Abstractions\ClassMethod) {
 				$methodNode = $this->getMethodNodeFromAbstraction($method);
-				if ($methodNode && $this->allPathsReturnOrThrow($methodNode, true)) {
+				if ($methodNode && $this->functionAlwaysThrows($methodNode)) {
 					$allThrow = true;
 				}
 			}
@@ -475,7 +495,7 @@ class ReturnCheck extends BaseCheck {
 		}
 
 		$methodNode = $this->getMethodNodeFromAbstraction($method);
-		return $methodNode && $this->allPathsReturnOrThrow($methodNode, true);
+		return $methodNode && $this->functionAlwaysThrows($methodNode);
 	}
 
 	/**

--- a/src/NodeVisitors/ThrowDetector.php
+++ b/src/NodeVisitors/ThrowDetector.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace BambooHR\Guardrail\NodeVisitors;
+
+/**
+ * Guardrail.  Copyright (c) 2016-2024, Jonathan Gardiner and BambooHR.
+ * Apache 2.0 License
+ */
+
+use PhpParser\Node;
+
+/**
+ * Detect whether a function/method literally always exits via throw or exit.
+ *
+ * Does not resolve cross-function calls — only structural patterns inside the
+ * function body (throw, exit, if/else, switch, try/catch, while(true), do/while).
+ * Used by the JSON symbol table indexer to set an `always_throws` attribute on
+ * each method/function before stmts are dropped from serialization, so that
+ * later checks can answer "does this call always throw?" without re-parsing.
+ */
+class ThrowDetector {
+	public static function functionAlwaysThrows(Node\FunctionLike $node): bool {
+		$stmts = $node->getStmts();
+		if (!$stmts) {
+			return false;
+		}
+		return self::statementsAlwaysThrow($stmts);
+	}
+
+	private static function statementsAlwaysThrow(array $stmts): bool {
+		$last = null;
+		for ($i = count($stmts) - 1; $i >= 0; $i--) {
+			if (!($stmts[$i] instanceof Node\Stmt\Nop)) {
+				$last = $stmts[$i];
+				break;
+			}
+		}
+		if (!$last) {
+			return false;
+		}
+		if ($last instanceof Node\Stmt\Throw_) {
+			return true;
+		}
+		if ($last instanceof Node\Stmt\Expression && $last->expr instanceof Node\Expr\Exit_) {
+			return true;
+		}
+		if ($last instanceof Node\Stmt\If_) {
+			if (!$last->else) {
+				return false;
+			}
+			if (!self::statementsAlwaysThrow($last->stmts)) {
+				return false;
+			}
+			if (!self::statementsAlwaysThrow($last->else->stmts)) {
+				return false;
+			}
+			foreach ($last->elseifs as $elseIf) {
+				if (!self::statementsAlwaysThrow($elseIf->stmts)) {
+					return false;
+				}
+			}
+			return true;
+		}
+		if ($last instanceof Node\Stmt\Switch_) {
+			$hasDefault = false;
+			foreach ($last->cases as $case) {
+				if ($case->cond === null) {
+					$hasDefault = true;
+				}
+				$caseStmts = $case->stmts;
+				while (($tail = end($caseStmts)) instanceof Node\Stmt\Break_ || $tail instanceof Node\Stmt\Nop) {
+					$caseStmts = array_slice($caseStmts, 0, -1);
+				}
+				if ($caseStmts && !self::statementsAlwaysThrow($caseStmts)) {
+					return false;
+				}
+			}
+			return $hasDefault;
+		}
+		if ($last instanceof Node\Stmt\TryCatch) {
+			if ($last->finally && self::statementsAlwaysThrow($last->finally->stmts)) {
+				return true;
+			}
+			if (!self::statementsAlwaysThrow($last->stmts)) {
+				return false;
+			}
+			foreach ($last->catches as $catch) {
+				if (!self::statementsAlwaysThrow($catch->stmts)) {
+					return false;
+				}
+			}
+			return true;
+		}
+		if ($last instanceof Node\Stmt\While_) {
+			if ($last->cond instanceof Node\Expr\ConstFetch && strtolower($last->cond->name->toString()) === 'true') {
+				return self::statementsAlwaysThrow($last->stmts);
+			}
+			return false;
+		}
+		if ($last instanceof Node\Stmt\Do_) {
+			return self::statementsAlwaysThrow($last->stmts);
+		}
+		return false;
+	}
+}

--- a/src/SymbolTable/JsonSymbolTable.php
+++ b/src/SymbolTable/JsonSymbolTable.php
@@ -12,6 +12,7 @@ use BambooHR\Guardrail\Abstractions\ClassAbstraction as AbstractClass;
 use BambooHR\Guardrail\Abstractions\ReflectedClass;
 use BambooHR\Guardrail\Abstractions\ReflectedFunction;
 use BambooHR\Guardrail\Evaluators\Expression\Scalar;
+use BambooHR\Guardrail\NodeVisitors\ThrowDetector;
 use BambooHR\Guardrail\NodeVisitors\VariadicCheckVisitor;
 use BambooHR\Guardrail\TypeComparer;
 use BambooHR\Guardrail\TypeParser;
@@ -330,6 +331,9 @@ class JsonSymbolTable extends SymbolTable implements PersistantSymbolTable {
 				if ($stmt->getAttribute('variadic_implementation', null) === null) {
 					$stmt->setAttribute("variadic_implementation", VariadicCheckVisitor::isVariadic($stmt->stmts));
 				}
+				if ($stmt->getAttribute('always_throws', null) === null) {
+					$stmt->setAttribute('always_throws', ThrowDetector::functionAlwaysThrows($stmt));
+				}
 				$stmt->stmts = [];
 			}
 		}
@@ -371,7 +375,24 @@ class JsonSymbolTable extends SymbolTable implements PersistantSymbolTable {
 				$usesTrait = 1;
 			}
 		}
+		self::annotateMethodAlwaysThrows($class);
 		$this->addType($name, $file, self::TYPE_CLASS, $usesTrait, $this->serializeClass($class));
+	}
+
+	/**
+	 * Set the `always_throws` attribute on every ClassMethod under this ClassLike
+	 * before its body gets dropped during serialization.
+	 *
+	 * @param ClassLike $class The class/interface/trait to annotate
+	 *
+	 * @return void
+	 */
+	public static function annotateMethodAlwaysThrows(ClassLike $class): void {
+		foreach ($class->stmts as $stmt) {
+			if ($stmt instanceof ClassMethod && $stmt->getAttribute('always_throws', null) === null) {
+				$stmt->setAttribute('always_throws', ThrowDetector::functionAlwaysThrows($stmt));
+			}
+		}
 	}
 
 	/**
@@ -440,6 +461,7 @@ class JsonSymbolTable extends SymbolTable implements PersistantSymbolTable {
 	 * @return void
 	 */
 	public function addInterface($name, Interface_ $interface, $file) {
+		self::annotateMethodAlwaysThrows($interface);
 		$this->addType($name, $file, self::TYPE_INTERFACE, 0, $this->serializeClass($interface));
 	}
 
@@ -455,8 +477,9 @@ class JsonSymbolTable extends SymbolTable implements PersistantSymbolTable {
 	public function addFunction($name, Function_ $function, $file) {
 		$clone = clone $function;
 		$clone->setAttribute("variadic_implementation", VariadicCheckVisitor::isVariadic($function->stmts));
+		$clone->setAttribute('always_throws', ThrowDetector::functionAlwaysThrows($function));
 		$clone->stmts = [];
-		$this->addType($name, $file, self::TYPE_FUNCTION, 0, $this->serializeFunction($function));
+		$this->addType($name, $file, self::TYPE_FUNCTION, 0, $this->serializeFunction($clone));
 	}
 
 	/**
@@ -577,6 +600,9 @@ class JsonSymbolTable extends SymbolTable implements PersistantSymbolTable {
 		if ($function->getAttribute("variadic_implementation")) {
 			$ret .= "V";
 		}
+		if ($function->getAttribute("always_throws")) {
+			$ret .= "R";
+		}
 		$ret .= ";";
 		return $ret;
 	}
@@ -615,6 +641,9 @@ class JsonSymbolTable extends SymbolTable implements PersistantSymbolTable {
 		}
 		if ($method->getAttribute('variadic_implementation')) {
 			$ret .= "V";
+		}
+		if ($method->getAttribute('always_throws')) {
+			$ret .= "R";
 		}
 		$ret .= ";";
 		return $ret;
@@ -715,7 +744,7 @@ class JsonSymbolTable extends SymbolTable implements PersistantSymbolTable {
 	}
 
 	function unserializeMethod(string $serializedMethod): ClassMethod {
-		preg_match('/^M([^ &]+)([ &])?([0-9]+)?\(([^)]*)\)(?::([0-9]+)?(?:@([0-9]+))?)?(?:T([0-9,]+))?(V)?$/', $serializedMethod, $matches);
+		preg_match('/^M([^ &]+)([ &])?([0-9]+)?\(([^)]*)\)(?::([0-9]+)?(?:@([0-9]+))?)?(?:T([0-9,]+))?(V)?(R)?$/', $serializedMethod, $matches);
 		$name = $matches[1];
 		$returnsByRef = isset($matches[2]) && $matches[2] == "&";
 		$flags = !empty($matches[3]) ? intval($matches[3]) : 0;
@@ -742,6 +771,9 @@ class JsonSymbolTable extends SymbolTable implements PersistantSymbolTable {
 		}
 		if (!empty($matches[8])) {
 			$method->setAttribute('variadic_implementation', true);
+		}
+		if (!empty($matches[9])) {
+			$method->setAttribute('always_throws', true);
 		}
 		return $method;
 	}
@@ -772,7 +804,7 @@ class JsonSymbolTable extends SymbolTable implements PersistantSymbolTable {
 
 
 	function unserializeFunction(string $serializedFunction): Function_ {
-		preg_match('/^F([^ &]+)(&)?\(([^)]*)\)(?::([0-9]+)?(?:@([0-9]+))?)?(?:T([0-9,]+))?(V)?;$/', $serializedFunction, $matches);
+		preg_match('/^F([^ &]+)(&)?\(([^)]*)\)(?::([0-9]+)?(?:@([0-9]+))?)?(?:T([0-9,]+))?(V)?(R)?;$/', $serializedFunction, $matches);
 		$name = new Node\Name\FullyQualified($matches[1]);
 		$returnsByRef = $matches[2] == "&";
 		if (trim($matches[3]) !== "") {
@@ -801,6 +833,9 @@ class JsonSymbolTable extends SymbolTable implements PersistantSymbolTable {
 		}
 		if (!empty($matches[7])) {
 			$func->setAttribute('variadic_implementation', true);
+		}
+		if (!empty($matches[8])) {
+			$func->setAttribute('always_throws', true);
 		}
 		return $func;
 	}

--- a/tests/units/Checks/TestData/TestReturnCheck-all-paths-throw-fail.inc
+++ b/tests/units/Checks/TestData/TestReturnCheck-all-paths-throw-fail.inc
@@ -1,5 +1,25 @@
 <?php declare(strict_types=1);
 
+function functionCallingThrowFunction(): int {
+	if (false) {
+		throwFunction();
+	}
+	// Missing else - no return or throw
+}
+
+function functionCallingThrowFunctionWithTryCatch(): int {
+	try {
+		$someValue = 5;
+		// Missing return or throw
+	} catch (\Exception $e) {
+		throwFunction();
+	}
+}
+
+function throwFunction(): void {
+	throw new \Exception();
+}
+
 // Function with no return and no throw - should fail
 function noReturnNoThrow(): int {
 	$x = 5;

--- a/tests/units/Checks/TestData/TestReturnCheck-all-paths-throw-fail.inc
+++ b/tests/units/Checks/TestData/TestReturnCheck-all-paths-throw-fail.inc
@@ -29,6 +29,67 @@ function returnFunction(): void {
 	return;
 }
 
+function whileFalseCallsThrowFunction(): int {
+	while (false) {
+		throwFunction();
+	}
+	// Missing return or throw - loop never executes
+}
+
+function switchWithoutDefaultCallsThrowFunction(int $x): int {
+	switch ($x) {
+		case 1:
+			throwFunction();
+		case 2:
+			throwFunction();
+		// Missing default case
+	}
+	// Missing return or throw
+}
+
+function tryNormalCatchThrows(): int {
+	try {
+		someNormalFunction();
+		// No throw or return in try
+	} catch (\Exception $e) {
+		throwFunction();
+	}
+	// Missing return after try-catch
+}
+
+// Method call that doesn't throw - should fail (methods not yet supported anyway)
+class NonThrowingClass {
+	public function normalMethod(): void {
+		echo "test";
+	}
+}
+
+function callMethodThatDoesntThrow(): int {
+	$obj = new NonThrowingClass();
+	$obj->normalMethod();
+	// Missing return or throw
+}
+
+class StaticNonThrowingClass {
+	public static function normalStaticMethod(): void {
+		echo "test";
+	}
+}
+
+function callStaticMethodThatDoesntThrow(): int {
+	StaticNonThrowingClass::normalStaticMethod();
+	// Missing return or throw
+}
+
+function functionCallingReturnFunction(): int {
+	returnFunction();
+	// Missing return or throw
+}
+
+function returnFunction(): void {
+	return;
+}
+
 // Function with no return and no throw - should fail
 function noReturnNoThrow(): int {
 	$x = 5;

--- a/tests/units/Checks/TestData/TestReturnCheck-all-paths-throw-fail.inc
+++ b/tests/units/Checks/TestData/TestReturnCheck-all-paths-throw-fail.inc
@@ -20,6 +20,15 @@ function throwFunction(): void {
 	throw new \Exception();
 }
 
+function functionCallingReturnFunction(): int {
+	returnFunction();
+	// Missing return or throw
+}
+
+function returnFunction(): void {
+	return;
+}
+
 // Function with no return and no throw - should fail
 function noReturnNoThrow(): int {
 	$x = 5;

--- a/tests/units/Checks/TestData/TestReturnCheck-all-paths-throw-fail.inc
+++ b/tests/units/Checks/TestData/TestReturnCheck-all-paths-throw-fail.inc
@@ -20,15 +20,6 @@ function throwFunction(): void {
 	throw new \Exception();
 }
 
-function functionCallingReturnFunction(): int {
-	returnFunction();
-	// Missing return or throw
-}
-
-function returnFunction(): void {
-	return;
-}
-
 function whileFalseCallsThrowFunction(): int {
 	while (false) {
 		throwFunction();

--- a/tests/units/Checks/TestData/TestReturnCheck-all-paths-throw-import.inc
+++ b/tests/units/Checks/TestData/TestReturnCheck-all-paths-throw-import.inc
@@ -1,0 +1,6 @@
+<?php declare(strict_types=1);
+use ThrowHelper;
+
+function functionCallingThrowFunction(): int {
+	ThrowHelper::throwFunction();
+}

--- a/tests/units/Checks/TestData/TestReturnCheck-all-paths-throw.inc
+++ b/tests/units/Checks/TestData/TestReturnCheck-all-paths-throw.inc
@@ -21,6 +21,96 @@ function throwFunction(): void {
 	throw new \Exception();
 }
 
+// Nested function calls that throw (3 levels deep)
+function functionCallingNestedThrowFunction(): int {
+	functionCallingAFunctionThatCallsThrowFunction();
+}
+
+// Function that throws in one branch but returns in another - should pass
+function mixedBranchesOneThrowsOneReturns(bool $flag): int {
+	if ($flag) {
+		throwFunction();
+	} else {
+		return 42;
+	}
+}
+
+// Switch statement with all cases calling throw functions
+function switchAllCasesCallThrowFunction(int $x): int {
+	switch ($x) {
+		case 1:
+			throwFunction();
+		case 2:
+			throwFunction();
+		default:
+			throwFunction();
+	}
+}
+
+// While loop with constant true calling throw function
+function whileTrueCallsThrowFunction(): int {
+	while (true) {
+		throwFunction();
+	}
+}
+
+// Exit after function call
+function callFunctionThenExit(): int {
+	someNormalFunction();
+	exit(1);
+}
+
+function someNormalFunction(): void {
+	echo "test";
+}
+
+// Try-catch where try calls throw function and catch also calls throw function
+function tryCatchBothCallThrowFunctions(): int {
+	try {
+		throwFunction();
+	} catch (\Exception $e) {
+		throwFunction();
+	}
+}
+
+// Finally block calling throw function (overrides)
+function finallyCallsThrowFunction(): int {
+	try {
+		return 42;
+	} finally {
+		throwFunction();
+	}
+}
+
+class ThrowingClass {
+	public function throwMethod(): void {
+		throw new \Exception();
+	}
+
+	public static function throwStaticMethod(): void {
+		throw new \Exception();
+	}
+
+	public function internalCallToThrowMethod(): void {
+		$this->throwMethod();
+	}
+}
+
+function callMethodThatThrows(): int {
+	$obj = new ThrowingClass();
+	$obj->throwMethod();
+}
+
+function callStaticMethodThatThrows(): int {
+	ThrowingClass::throwStaticMethod();
+}
+
+function doWhileCallsThrowFunctionFalse(): int {
+	do {
+		throwFunction();
+	} while (false);
+}
+
 function testFunction(): int {
 	throw new \Exception();
 }

--- a/tests/units/Checks/TestData/TestReturnCheck-all-paths-throw.inc
+++ b/tests/units/Checks/TestData/TestReturnCheck-all-paths-throw.inc
@@ -1,5 +1,28 @@
 <?php declare(strict_types=1);
 
+function functionCallingThrowFunction(): int {
+	throwFunction();
+}
+
+function functionCallingAFunctionThatCallsThrowFunction(): int {
+	functionCallingThrowFunction();
+}
+
+function functionCallingThrowFunctionWithTryCatch(): int {
+	try {
+		$someValue = 5;
+		throwFunction();
+	} catch (\Exception $e) {
+		throw $e;
+	}
+}
+
+function throwFunction(): void {
+	throw new \Exception();
+}
+
+
+
 function testFunction(): int {
 	throw new \Exception();
 }

--- a/tests/units/Checks/TestData/TestReturnCheck-all-paths-throw.inc
+++ b/tests/units/Checks/TestData/TestReturnCheck-all-paths-throw.inc
@@ -21,8 +21,6 @@ function throwFunction(): void {
 	throw new \Exception();
 }
 
-
-
 function testFunction(): int {
 	throw new \Exception();
 }

--- a/tests/units/Checks/TestData/TestReturnCheck-all-paths-throw.inc
+++ b/tests/units/Checks/TestData/TestReturnCheck-all-paths-throw.inc
@@ -21,11 +21,6 @@ function throwFunction(): void {
 	throw new \Exception();
 }
 
-// Nested function calls that throw (3 levels deep)
-function functionCallingNestedThrowFunction(): int {
-	functionCallingAFunctionThatCallsThrowFunction();
-}
-
 // Function that throws in one branch but returns in another - should pass
 function mixedBranchesOneThrowsOneReturns(bool $flag): int {
 	if ($flag) {
@@ -52,16 +47,6 @@ function whileTrueCallsThrowFunction(): int {
 	while (true) {
 		throwFunction();
 	}
-}
-
-// Exit after function call
-function callFunctionThenExit(): int {
-	someNormalFunction();
-	exit(1);
-}
-
-function someNormalFunction(): void {
-	echo "test";
 }
 
 // Try-catch where try calls throw function and catch also calls throw function

--- a/tests/units/Checks/TestData/ThrowHelper.php
+++ b/tests/units/Checks/TestData/ThrowHelper.php
@@ -1,0 +1,7 @@
+<?php
+
+class ThrowHelper {
+    public static function throwFunction(): void {
+	    throw new \Exception();
+    }
+}

--- a/tests/units/Checks/TestReturnCheck.php
+++ b/tests/units/Checks/TestReturnCheck.php
@@ -71,7 +71,7 @@ class TestReturnCheck extends TestSuiteSetup {
 	public function testAllPathsThrowFail() {
 		// 44 invalid functions/methods where not all paths return or throw
 		// Includes: nested incomplete structures, try-finally incomplete, deeply nested incomplete, fall through failures
-		$this->assertEquals(46, $this->runAnalyzerOnFile('-all-paths-throw-fail.inc', ErrorConstants::TYPE_SIGNATURE_RETURN), "Failed to catch functions where not all paths throw or return");
+		$this->assertEquals(47, $this->runAnalyzerOnFile('-all-paths-throw-fail.inc', ErrorConstants::TYPE_SIGNATURE_RETURN), "Failed to catch functions where not all paths throw or return");
 	}
 
 	public function testWhileIFConstant() {

--- a/tests/units/Checks/TestReturnCheck.php
+++ b/tests/units/Checks/TestReturnCheck.php
@@ -68,7 +68,7 @@ class TestReturnCheck extends TestSuiteSetup {
 	}
 
 	public function testAllPathsThrowFail() {
-		$this->assertEquals(53, $this->runAnalyzerOnFile('-all-paths-throw-fail.inc', ErrorConstants::TYPE_SIGNATURE_RETURN), "Failed to catch functions where not all paths throw or return");
+		$this->assertEquals(52, $this->runAnalyzerOnFile('-all-paths-throw-fail.inc', ErrorConstants::TYPE_SIGNATURE_RETURN), "Failed to catch functions where not all paths throw or return");
 	}
 
 	public function testWhileIFConstant() {

--- a/tests/units/Checks/TestReturnCheck.php
+++ b/tests/units/Checks/TestReturnCheck.php
@@ -71,7 +71,7 @@ class TestReturnCheck extends TestSuiteSetup {
 	public function testAllPathsThrowFail() {
 		// 44 invalid functions/methods where not all paths return or throw
 		// Includes: nested incomplete structures, try-finally incomplete, deeply nested incomplete, fall through failures
-		$this->assertEquals(44, $this->runAnalyzerOnFile('-all-paths-throw-fail.inc', ErrorConstants::TYPE_SIGNATURE_RETURN), "Failed to catch functions where not all paths throw or return");
+		$this->assertEquals(46, $this->runAnalyzerOnFile('-all-paths-throw-fail.inc', ErrorConstants::TYPE_SIGNATURE_RETURN), "Failed to catch functions where not all paths throw or return");
 	}
 
 	public function testWhileIFConstant() {

--- a/tests/units/Checks/TestReturnCheck.php
+++ b/tests/units/Checks/TestReturnCheck.php
@@ -63,15 +63,12 @@ class TestReturnCheck extends TestSuiteSetup {
 		$this->assertEquals(20, $this->runAnalyzerOnFile('-standard-returns-fail.inc', ErrorConstants::TYPE_SIGNATURE_RETURN), "Failed to fail standard return types");
 	}
 	public function testAllPathsThrowNoReturnNoError() {
-		// 45 valid functions/methods where all paths return or throw
-		// Includes: nested structures, die(), try-finally, deeply nested, switch variations
+		// All function that should pass
 		$this->assertEquals(0, $this->runAnalyzerOnFile('-all-paths-throw.inc', ErrorConstants::TYPE_SIGNATURE_RETURN), "Failed to pass functions where all paths throw exceptions");
 	}
 
 	public function testAllPathsThrowFail() {
-		// 44 invalid functions/methods where not all paths return or throw
-		// Includes: nested incomplete structures, try-finally incomplete, deeply nested incomplete, fall through failures
-		$this->assertEquals(47, $this->runAnalyzerOnFile('-all-paths-throw-fail.inc', ErrorConstants::TYPE_SIGNATURE_RETURN), "Failed to catch functions where not all paths throw or return");
+		$this->assertEquals(53, $this->runAnalyzerOnFile('-all-paths-throw-fail.inc', ErrorConstants::TYPE_SIGNATURE_RETURN), "Failed to catch functions where not all paths throw or return");
 	}
 
 	public function testWhileIFConstant() {

--- a/tests/units/Checks/TestReturnCheck.php
+++ b/tests/units/Checks/TestReturnCheck.php
@@ -62,9 +62,15 @@ class TestReturnCheck extends TestSuiteSetup {
 		// 20 invalid type mismatches (10 in class methods + 10 in standalone functions)
 		$this->assertEquals(20, $this->runAnalyzerOnFile('-standard-returns-fail.inc', ErrorConstants::TYPE_SIGNATURE_RETURN), "Failed to fail standard return types");
 	}
+
 	public function testAllPathsThrowNoReturnNoError() {
 		// All function that should pass
 		$this->assertEquals(0, $this->runAnalyzerOnFile('-all-paths-throw.inc', ErrorConstants::TYPE_SIGNATURE_RETURN), "Failed to pass functions where all paths throw exceptions");
+	}
+
+	public function testAllPathsThrowNoReturnImportNoError() {
+		// All function that should pass
+		$this->assertEquals(0, $this->runAnalyzerOnFile('-all-paths-throw-import.inc', ErrorConstants::TYPE_SIGNATURE_RETURN, ['additionalFilesToIndex' => [__DIR__ . '/TestData/ThrowHelper.php']]), "Failed to pass functions where all paths throw exceptions");
 	}
 
 	public function testAllPathsThrowFail() {


### PR DESCRIPTION
### Problem:
The following code is legitimate; but guardrail doesn't think it is

```
function throwFunction () {
  throw Exception;
}

function anotherFunction(bool myBool): int {
  if (myBool) {
    return 1; 
  }
  throwFunction()
}
```

### Solution:
Check if underlying functions throw.

- Added new tests
- Added a `throwOnly` option to several functions that previously checked for return or throw
- Add new functions to handle when a function calls a function / method / staticmethod