### PR TITLE
fix: don't false-positive unused vars used in arrow fn ternary

### DIFF
--- a/src/Evaluators/Expression/FunctionLike.php
+++ b/src/Evaluators/Expression/FunctionLike.php
@@ -17,21 +17,28 @@ class FunctionLike implements ExpressionInterface
 
 	function onExit(Node $node, SymbolTable $table, ScopeStack $scopeStack): ?Node {
 		\BambooHR\Guardrail\Evaluators\FunctionLike::handleUnusedVars($scopeStack);
-		$closureScope = $scopeStack->popScope();
+		$scopeStack->popScope();
+
+		// Use the function-scope attribute directly rather than the popped top-of-stack scope.
+		// When the function body contains a ternary, scope branching can leave a cloned scope
+		// (with stale `used` flags) on top of the stack instead of the original function-scope.
+		// The function-scope attribute is always written to by setVarUsed(), so it is the
+		// authoritative source for which variables were actually referenced.
+		$fnScope = $node->getAttribute('function-scope');
 
 		if ($node instanceof Node\Expr\Closure) {
 			$uses = array_map(
 				fn(Node\Expr\ClosureUse $closureUse): string => $closureUse->var->name,
 				$node->uses
 			);
-			foreach ($closureScope->getUsedVars() as $var) {
+			foreach ($fnScope->getUsedVars() as $var) {
 				/** @var Scope\ScopeVar $var */
 				if ($scopeStack->getVarExists($var->name) && $var->used && in_array($var->name, $uses)) {
 					$scopeStack->setVarUsed($var->name);
 				}
 			}
 		} elseif ($node instanceof Node\Expr\ArrowFunction) {
-			foreach ($closureScope->getUsedVars() as $var) {
+			foreach ($fnScope->getUsedVars() as $var) {
 				/** @var Scope\ScopeVar $var */
 				if ($scopeStack->getVarExists($var->name) && $var->used) {
 					$scopeStack->setVarUsed($var->name);

--- a/tests/units/Checks/TestData/TestUnusedVars.5.inc
+++ b/tests/units/Checks/TestData/TestUnusedVars.5.inc
@@ -1,0 +1,19 @@
+<?php
+
+class TestUnusedVarsArrowFnTernary {
+	function testVariablesUsedInArrowFunctionTernary(): void {
+		$results = [1, 2, 3];
+		$customFieldValues = ['a', 'b', 'c'];
+		$customFields = ['x' => true];
+
+		return array_map(
+			fn($fieldType, $fieldId) => isset($customFields[$fieldId]) ? (
+				$customFieldValues[0]
+			) : (
+				$results[0]
+			),
+			['type1', 'type2'],
+			['x', 'y']
+		);
+	}
+}

--- a/tests/units/Checks/TestData/TestUnusedVars.6.inc
+++ b/tests/units/Checks/TestData/TestUnusedVars.6.inc
@@ -1,0 +1,20 @@
+<?php
+
+class TestUnusedVarsArrowFnTernaryNegative {
+	function testVariableNotUsedInArrowFunctionTernary(): void {
+		$results = [1, 2, 3];
+		$customFieldValues = ['a', 'b', 'c'];
+		$customFields = ['x' => true];
+		$neverUsed = 'unused';
+
+		return array_map(
+			fn($fieldType, $fieldId) => isset($customFields[$fieldId]) ? (
+				$customFieldValues[0]
+			) : (
+				$results[0]
+			),
+			['type1', 'type2'],
+			['x', 'y']
+		);
+	}
+}

--- a/tests/units/Checks/TestUnusedVars.php
+++ b/tests/units/Checks/TestUnusedVars.php
@@ -28,4 +28,8 @@ class TestUnusedVars extends TestSuiteSetup {
 		$this->assertEquals(0, $this->runAnalyzerOnFile('.4.inc', ErrorConstants::TYPE_UNUSED_VARIABLE), "");
 		$this->assertEquals(0, $this->runAnalyzerOnFile('.4.inc', ErrorConstants::TYPE_AUTOLOAD_ERROR), "");
 	}
+
+	public function testVariablesUsedInArrowFunctionTernaryAreNotFlaggedAsUnused() {
+		$this->assertEquals(0, $this->runAnalyzerOnFile('.5.inc', ErrorConstants::TYPE_UNUSED_VARIABLE), "");
+	}
 }

--- a/tests/units/Checks/TestUnusedVars.php
+++ b/tests/units/Checks/TestUnusedVars.php
@@ -32,4 +32,8 @@ class TestUnusedVars extends TestSuiteSetup {
 	public function testVariablesUsedInArrowFunctionTernaryAreNotFlaggedAsUnused() {
 		$this->assertEquals(0, $this->runAnalyzerOnFile('.5.inc', ErrorConstants::TYPE_UNUSED_VARIABLE), "");
 	}
+
+	public function testVariableNotUsedInArrowFunctionTernaryIsFlagged() {
+		$this->assertEquals(1, $this->runAnalyzerOnFile('.6.inc', ErrorConstants::TYPE_UNUSED_VARIABLE), "");
+	}
 }


### PR DESCRIPTION
## Summary

- Fixes a false-positive `Standard.Unused.Variable` error for variables that are assigned in an outer function and then only referenced inside an arrow function body that contains a ternary expression.
- Applies the same correctness fix to the `Closure` branch for consistency.
- Adds a regression test (`TestUnusedVars.5.inc`) covering exactly the pattern from the ticket.

## Root cause

When an arrow function body contains a ternary, `Expression::onEnter(Ternary)` clones the arrow function's scope and pushes the clone. After the ternary is processed, the `pop-scope-on-leave` handler pops the original arrow function scope (used as the else-branch) and merges it into the clone — but `ScopeVar::mergeVar` does **not** propagate the `used` flag. The clone (with stale `used = false`) ends up on top of the stack.

`Expression/FunctionLike::onExit` was reading used-vars from that popped top-of-stack clone, so variables only marked used via `setVarUsed()` on the `function-scope` attribute were missed, and they were never propagated as used back to the outer function.

## Fix

Read used-vars from `$node->getAttribute('function-scope')` — the authoritative scope object that `setVarUsed()` always writes to — rather than from the popped top-of-stack clone.