### PR TITLE
rshakespear/speed-3253-techdocs-guardrail

### DIFF
--- a/.github/workflows/techdocs.yaml
+++ b/.github/workflows/techdocs.yaml
@@ -1,0 +1,26 @@
+name: TechDocs
+
+# Publishes this repo's TechDocs (rendered HTML + raw markdown) to the
+# bhr-techdocs S3 bucket via the org-standard reusable workflow. Runs after
+# merge to master so the Backstage Docs tab reflects the published source.
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - docs/**
+      - mkdocs.yml
+      - .github/workflows/techdocs.yaml
+  workflow_dispatch:
+
+jobs:
+  techdocs:
+    uses: BambooHR/actions/.github/workflows/techdocs.yaml@main
+    permissions:
+      id-token: write # required for OIDC -> assume-role
+      contents: read
+    with:
+      entity-namespace: default
+      entity-kind: Component
+      entity-name: guardrail

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,3 @@
 # Guardrail
 
 BambooHR tool to run static analysis.
-
-This is the TechDocs landing page for the `guardrail` Backstage entity. See the
-surrounding pages (e.g. plugins) for available documentation; further
-documentation is maintained by the owning team (Speed Demons).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,7 @@
+# Guardrail
+
+BambooHR tool to run static analysis.
+
+This is the TechDocs landing page for the `guardrail` Backstage entity. See the
+surrounding pages (e.g. plugins) for available documentation; further
+documentation is maintained by the owning team (Speed Demons).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,5 @@
+site_name: Guardrail
+docs_dir: docs
+
+plugins:
+  - techdocs-core


### PR DESCRIPTION
## Summary
Onboards the `guardrail` repo to the TechDocs external-builder pipeline (epic SPEED-3245), following the pattern validated in backstage (#1052).

- `mkdocs.yml`: `site_name: Guardrail`, `docs_dir: docs`, `techdocs-core` plugin
- `docs/index.md`: minimal landing page (repo had no docs home page)
- `.github/workflows/techdocs.yaml`: caller for the reusable TechDocs workflow, triplet `default/Component/guardrail`, runs on push to `master` (docs paths) + `workflow_dispatch`

`metadata.yaml` already carries `backstage.io/techdocs-ref: dir:.`.

## Jira
https://bamboohr.atlassian.net/browse/SPEED-3253
