### PR TITLE
SPEED-3390: Remove stale TechDocs annotation from metadata.yaml

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -3,8 +3,6 @@ kind: Component
 metadata:
   name: guardrail
   description: BambooHR tool to run Static Analysis
-  annotations:
-    backstage.io/techdocs-ref: dir:.
 spec:
   type: library
   owner: speed-demons


### PR DESCRIPTION
## Summary
- Removes the leftover `backstage.io/techdocs-ref: dir:.` annotation (and the now-empty `annotations:` block) from `metadata.yaml`. TechDocs was added in #170 and reverted in #171, but this annotation was left behind, so guardrail still shows up in the Backstage Docs index despite having no docs.
- Repo-wide search confirms no other TechDocs/mkdocs remnants (no `mkdocs.yml`, no CI build steps). `docs/plugins.md` was reviewed and kept — it's genuine plugin documentation linked from the README, not an mkdocs artifact.

## Notes
- After merge, the Backstage catalog picks this up on its regular sync; to see it immediately, hit refresh on the guardrail entity's About card in Backstage.
- Cleaning up stale built docs in the TechDocs S3 bucket is out of scope.

## Test plan
- [x] `metadata.yaml` parses as valid YAML; kind/name/spec fields unchanged
- [x] `grep -i techdocs` returns nothing repo-wide