### PR TITLE
fix: don't report a declared static enum values() as a non-static call

### DIFF
--- a/src/EnumCodeAugmenter.php
+++ b/src/EnumCodeAugmenter.php
@@ -15,7 +15,7 @@ class EnumCodeAugmenter {
 		$enum->stmts[] = $property->getNode();
 		$enum->stmts[] = new Node\Stmt\ClassMethod("cases", ["returnType" => "array", "flags" => Node\Stmt\Class_::MODIFIER_PUBLIC | Node\Stmt\Class_::MODIFIER_STATIC]);
 		if ($isBacked) {
-			$enum->stmts[] = new Node\Stmt\ClassMethod("values", ["returnType" => "array"]);
+			$enum->stmts[] = new Node\Stmt\ClassMethod("values", ["returnType" => "array", "flags" => Node\Stmt\Class_::MODIFIER_PUBLIC | Node\Stmt\Class_::MODIFIER_STATIC]);
 			$property = new Property("value");
 			$property->makeReadonly();
 			$property->setType($enum->scalarType);

--- a/tests/units/SymbolTable/JsonSymbolTableEnumTest.php
+++ b/tests/units/SymbolTable/JsonSymbolTableEnumTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace BambooHR\Guardrail\Tests\SymbolTable;
+
+use BambooHR\Guardrail\EnumCodeAugmenter;
+use BambooHR\Guardrail\SymbolTable\JsonSymbolTable;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Enum_;
+use PhpParser\NodeFinder;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\ParserFactory;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The augmented enum members must survive a symbol table round trip with their modifiers
+ * intact.
+ *
+ * `unserializeClassMembers()` keys members by lowercased name, so a synthesized member and
+ * a developer-declared member of the same name collapse into one entry and the later write
+ * wins. That makes the modifiers on a synthesized member load-bearing: if they disagree
+ * with the real declaration, the real one is replaced by a wrong description of itself.
+ *
+ * Note that these tests exercise `JsonSymbolTable` specifically. The check-level test
+ * suite runs on `InMemorySymbolTable`, which keeps the parsed node and never round trips,
+ * so it cannot observe this class of problem.
+ */
+class JsonSymbolTableEnumTest extends TestCase {
+
+	/**
+	 * @param string $code PHP source declaring exactly one enum
+	 *
+	 * @return Enum_
+	 */
+	private function augmentedEnum(string $code): Enum_ {
+		$parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
+		$traverser = new NodeTraverser();
+		$traverser->addVisitor(new NameResolver());
+		$ast = $traverser->traverse($parser->parse($code));
+
+		$enum = (new NodeFinder())->findFirstInstanceOf($ast, Enum_::class);
+		EnumCodeAugmenter::addEnumPropsAndMethods($enum);
+
+		return $enum;
+	}
+
+	/**
+	 * @param Enum_ $enum The enum to round trip
+	 *
+	 * @return Enum_
+	 */
+	private function roundTrip(Enum_ $enum): Enum_ {
+		$table = new JsonSymbolTable(tempnam(sys_get_temp_dir(), "guardrail-test"), sys_get_temp_dir());
+
+		return $table->unserializeClass($table->serializeClass($enum));
+	}
+
+	/**
+	 * A backed enum may declare its own `values()` helper. `values()` is not part of the
+	 * enum language contract, so the name is not reserved and the declaration stands.
+	 *
+	 * @return void
+	 */
+	public function testDeclaredStaticValuesSurvivesTheRoundTripAsStatic() {
+		$enum = $this->augmentedEnum('<?php
+			enum SomeBackedEnum: string {
+				case Foo = "foo";
+				case Bar = "bar";
+
+				public static function values(): array {
+					return array_column(self::cases(), "value");
+				}
+			}
+		');
+
+		$method = $this->roundTrip($enum)->getMethod("values");
+
+		$this->assertNotNull($method, "values() must exist after the round trip");
+		$this->assertTrue(
+			$method->isStatic(),
+			"A declared `public static function values()` must not come back non-static"
+		);
+	}
+
+	/**
+	 * The same guarantee for a backed enum that declares nothing of its own: the
+	 * synthesized `values()` is a static method, matching cases(), from() and tryFrom().
+	 *
+	 * @return void
+	 */
+	public function testSynthesizedValuesIsStatic() {
+		$enum = $this->augmentedEnum('<?php
+			enum PlainBackedEnum: string {
+				case Foo = "foo";
+			}
+		');
+
+		$this->assertTrue(
+			$this->roundTrip($enum)->getMethod("values")->isStatic(),
+			"The synthesized values() must be static, as its siblings are"
+		);
+	}
+
+	/**
+	 * Guards the collapse itself: whichever entry survives, exactly one `values()` must be
+	 * present so the surviving modifiers are unambiguous.
+	 *
+	 * @return void
+	 */
+	public function testOnlyOneValuesEntrySurvivesTheRoundTrip() {
+		$enum = $this->augmentedEnum('<?php
+			enum AnotherBackedEnum: string {
+				case Foo = "foo";
+
+				public static function values(): array {
+					return [];
+				}
+			}
+		');
+
+		$surviving = array_filter(
+			$this->roundTrip($enum)->stmts,
+			fn($stmt) => $stmt instanceof ClassMethod && $stmt->name->toString() === "values"
+		);
+
+		$this->assertCount(1, $surviving);
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes a false-positive `Standard.Incorrect.Dynamic` for any backed enum that declares its own `public static function values()`. Every static call to it is reported as `Attempt to call non-static method: SomeEnum::values statically`.
- Gives the synthesized `values()` the same flags as the synthesized `cases()`, which is a one-line change.
- Adds `JsonSymbolTableEnumTest`, a regression test that round trips an augmented enum through `JsonSymbolTable`. Two of its three cases fail without this change.

This is not theoretical. In a large codebase we maintain, another team hit this same false positive independently and worked around it with two `@guardrail-ignore Standard.Incorrect.Dynamic` annotations, whose stated reason is literally that the method is static. Eleven backed enums there declare their own `values()` and are called statically across thirteen call sites, so each one produces this error the next time its file changes.

`values()` is not part of the enum language contract. PHP provides `cases()`, plus `from()` and `tryFrom()` on backed enums, and nothing else, so the name is not reserved and a developer-declared `values()` should be honoured as written. Since PHP raises a fatal `Error` when a genuinely non-static method is called statically, affected code demonstrably runs, which is what makes this a false positive rather than a finding.

## Root cause

`EnumCodeAugmenter::addEnumPropsAndMethods()` appends a synthesized `values()` with no flags, which makes it non-static, while its three siblings all receive `MODIFIER_STATIC`:

```php
$enum->stmts[] = new ClassMethod("cases",   ["returnType" => "array", "flags" => MODIFIER_PUBLIC | MODIFIER_STATIC]);
$enum->stmts[] = new ClassMethod("values",  ["returnType" => "array"]);   // no flags
$enum->stmts[] = new ClassMethod("tryFrom", [..., "flags" => MODIFIER_STATIC, ...]);
$enum->stmts[] = new ClassMethod("from",    [..., "flags" => MODIFIER_STATIC, ...]);
```

On its own that is harmless. The synthesized member is appended after the real one, and `ClassLike::getMethod()` returns the first match, so an in-memory lookup still finds the developer's static declaration.

It becomes visible after a symbol table round trip. `JsonSymbolTable::unserializeClassMembers()` keys members by lowercased name:

```php
$stmts["M" . strtolower($method->name)] = $method;
```

Both entries claim `mvalues`, the later write wins, and the developer's `public static` declaration is replaced by the non-static synthesized description of itself. `StaticCallCheck` then reads `$method->isStatic()` as `false` and emits the error.

Demonstrated by round tripping an augmented enum that declares `public static function values()`:

```
as parsed, before augmentation:  isStatic=true
after augmentation:              values(isStatic=true), values(isStatic=false)
getMethod() (first match):       isStatic=true
after JsonSymbolTable round trip: isStatic=false      <- one entry survives, the wrong one
```

With this change the surviving entry is static, and the false positive disappears.

## Fix

Give the synthesized `values()` the same flags as `cases()`.

## Test plan

- [x] `JsonSymbolTableEnumTest` fails without the fix (2 of 3 cases) and passes with it
- [x] Full unit suite: 364 tests, no failures
- [x] `phpcs --standard=./.phpcs.xml src/ -s` clean
- [x] Guardrail indexes and analyzes itself with zero errors

The new test targets `JsonSymbolTable` deliberately. The check-level suite runs on `InMemorySymbolTable`, which keeps the parsed node and never round trips, so it structurally cannot observe this class of problem. That is why the existing `testEnumCasesMethodIsStatic()` passes today even though the equivalent real-world call fails.

## Two observations, both out of scope here

1. The keyed merge in `unserializeClassMembers()` means **any** developer-declared member whose name collides with a synthesized one is silently replaced, along with its modifiers, return type and signature. `values()` is the instance we hit; the mechanism is general. Preferring the real declaration on collision, or emitting a diagnostic, would remove the whole class of problem rather than this one case. Happy to open a separate issue if that is useful.
2. Consider whether `values()` should be synthesized at all, given it is not a language method. Leaving it in place here to keep the change minimal, since existing code may rely on it resolving.
