### PR TITLE
fix: stop synthesizing a values() method onto backed enums

### DIFF
--- a/src/EnumCodeAugmenter.php
+++ b/src/EnumCodeAugmenter.php
@@ -15,7 +15,6 @@ class EnumCodeAugmenter {
 		$enum->stmts[] = $property->getNode();
 		$enum->stmts[] = new Node\Stmt\ClassMethod("cases", ["returnType" => "array", "flags" => Node\Stmt\Class_::MODIFIER_PUBLIC | Node\Stmt\Class_::MODIFIER_STATIC]);
 		if ($isBacked) {
-			$enum->stmts[] = new Node\Stmt\ClassMethod("values", ["returnType" => "array"]);
 			$property = new Property("value");
 			$property->makeReadonly();
 			$property->setType($enum->scalarType);

--- a/tests/units/Checks/TestData/TestStaticCallCheck.EnumValuesUndeclared.inc
+++ b/tests/units/Checks/TestData/TestStaticCallCheck.EnumValuesUndeclared.inc
@@ -1,0 +1,8 @@
+<?php
+
+enum UndeclaredValuesEnum: string
+{
+    case Foo = 'foo';
+}
+
+UndeclaredValuesEnum::values();

--- a/tests/units/Checks/TestStaticCallCheck.php
+++ b/tests/units/Checks/TestStaticCallCheck.php
@@ -40,4 +40,25 @@ class TestStaticCallCheck extends TestSuiteSetup {
 	public function testEnumCasesMethodIsStatic() {
 		$this->assertEquals(0, $this->runAnalyzerOnFile('.EnumCasesCall.inc', ErrorConstants::TYPE_INCORRECT_DYNAMIC_CALL));
 	}
+
+	/**
+	 * `values()` is not an enum method: PHP provides `cases()` on every enum and
+	 * `from()`/`tryFrom()` on backed enums, and nothing else. A call to it on an enum that
+	 * declares no such method is undefined at runtime and must be reported as one.
+	 *
+	 * @return void
+	 */
+	public function testUndeclaredEnumValuesIsAnUnknownMethod() {
+		$this->assertEquals(1, $this->runAnalyzerOnFile('.EnumValuesUndeclared.inc', ErrorConstants::TYPE_UNKNOWN_METHOD));
+	}
+
+	/**
+	 * The same call must not ALSO be reported as a static-call problem, which is what
+	 * happens when a non-static method is invented to satisfy it.
+	 *
+	 * @return void
+	 */
+	public function testUndeclaredEnumValuesIsNotReportedAsADynamicCall() {
+		$this->assertEquals(0, $this->runAnalyzerOnFile('.EnumValuesUndeclared.inc', ErrorConstants::TYPE_INCORRECT_DYNAMIC_CALL));
+	}
 }

--- a/tests/units/SymbolTable/JsonSymbolTableEnumTest.php
+++ b/tests/units/SymbolTable/JsonSymbolTableEnumTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace BambooHR\Guardrail\Tests\units\SymbolTable;
+
+use BambooHR\Guardrail\EnumCodeAugmenter;
+use BambooHR\Guardrail\SymbolTable\JsonSymbolTable;
+use PhpParser\Node\Stmt\Enum_;
+use PhpParser\NodeFinder;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\ParserFactory;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A developer-declared enum member must survive a symbol table round trip exactly as
+ * written.
+ *
+ * `unserializeClassMembers()` keys members by lowercased name, so two members of the same
+ * name collapse into one entry and the later write wins. Anything the augmenter adds is
+ * appended after the parsed members, so an augmented member of the same name as a declared
+ * one replaces it, taking its modifiers with it.
+ *
+ * These tests exercise `JsonSymbolTable` directly. The check-level suite runs on
+ * `InMemorySymbolTable`, which keeps the parsed node and never round trips, so it cannot
+ * observe this.
+ */
+class JsonSymbolTableEnumTest extends TestCase {
+	/**
+	 * @param string $code PHP source declaring exactly one enum
+	 *
+	 * @return Enum_
+	 */
+	private function roundTrip(string $code): Enum_ {
+		$parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
+		$traverser = new NodeTraverser();
+		$traverser->addVisitor(new NameResolver());
+		$ast = $traverser->traverse($parser->parse($code));
+
+		$enum = (new NodeFinder())->findFirstInstanceOf($ast, Enum_::class);
+		EnumCodeAugmenter::addEnumPropsAndMethods($enum);
+
+		$table = new JsonSymbolTable(tempnam(sys_get_temp_dir(), "guardrail-test"), sys_get_temp_dir());
+
+		return $table->unserializeClass($table->serializeClass($enum));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDeclaredStaticValuesStaysStatic() {
+		$enum = $this->roundTrip('<?php
+			enum SomeBackedEnum: string {
+				case Foo = "foo";
+
+				public static function values(): array {
+					return array_column(self::cases(), "value");
+				}
+			}
+		');
+
+		$method = $enum->getMethod("values");
+
+		$this->assertNotNull($method, "A declared values() must survive the round trip");
+		$this->assertTrue($method->isStatic(), "A declared static values() must stay static");
+	}
+
+	/**
+	 * The same guarantee in the other direction: an instance method must not come back
+	 * static, or a static call to it would be wrongly accepted.
+	 *
+	 * @return void
+	 */
+	public function testDeclaredInstanceValuesStaysAnInstanceMethod() {
+		$enum = $this->roundTrip('<?php
+			enum AnotherBackedEnum: string {
+				case Foo = "foo";
+
+				public function values(): array {
+					return [];
+				}
+			}
+		');
+
+		$method = $enum->getMethod("values");
+
+		$this->assertNotNull($method, "A declared values() must survive the round trip");
+		$this->assertFalse($method->isStatic(), "A declared instance values() must not become static");
+	}
+
+	/**
+	 * `values()` is not part of the enum language contract, so a backed enum that declares
+	 * none must not gain one. Inventing it hides calls that are undefined at runtime.
+	 *
+	 * @return void
+	 */
+	public function testBackedEnumGainsNoValuesMethodOfItsOwn() {
+		$enum = $this->roundTrip('<?php
+			enum PlainBackedEnum: string {
+				case Foo = "foo";
+			}
+		');
+
+		$this->assertNull($enum->getMethod("values"));
+	}
+
+	/**
+	 * The members PHP really does provide are still present, and static.
+	 *
+	 * @return void
+	 */
+	public function testLanguageProvidedMembersSurviveAsStatic() {
+		$enum = $this->roundTrip('<?php
+			enum LanguageMembersEnum: string {
+				case Foo = "foo";
+			}
+		');
+
+		foreach (["cases", "from", "tryFrom"] as $name) {
+			$method = $enum->getMethod($name);
+			$this->assertNotNull($method, "$name() must be present on a backed enum");
+			$this->assertTrue($method->isStatic(), "$name() must be static");
+		}
+	}
+}


### PR DESCRIPTION
## Summary

We added a new backed enum with the `public static function values()` helper our codebase uses everywhere, and CI failed with `Standard.Incorrect.Dynamic: Attempt to call non-static method: SomeEnum::values statically`. The method is declared static, reflection agrees, and PHP raises a fatal `Error` when a genuinely non-static method is called statically, so the code demonstrably runs. Something was wrong in the analyzer, not the code.

Then we found two `@guardrail-ignore Standard.Incorrect.Dynamic` annotations already sitting in our codebase, whose stated reason is literally that the method is static. Another team hit this, reached the same conclusion, suppressed it and moved on. Nothing was ever filed. Eleven backed enums there declare their own `values()` and are called statically across thirteen call sites, so each one produces this error the next time its file changes.

Tracing it: `EnumCodeAugmenter` synthesizes `values()` onto every backed enum, but `values()` is not part of the enum language contract. PHP provides `cases()`, plus `from()` and `tryFrom()` on backed enums, and nothing else. So the synthesized member is not filling a gap, it is shadowing real hand-written code. It overwrites the developer's declaration on the way out of the symbol table, and because it carries no flags, the surviving description of the method is non-static.

It also has a quieter cost: a call to `values()` on an enum that declares none is a runtime fatal, and the synthesized member silently satisfies it, so `Standard.Unknown.Class.Method` never fires.

The fix is to delete the line that synthesizes it. Both problems go away, and nothing needs to replace it, because a hand-written `values()` is already visible from source.

## Root cause

PHP provides `cases()` on every enum, plus `from()` and `tryFrom()` on backed enums. Nothing else. `EnumCodeAugmenter` correctly synthesizes those three, and additionally synthesizes `values()`, which the language never creates. That causes two distinct problems.

**It hides real errors.** A call to `SomeEnum::values()` on an enum that declares no such method is a runtime fatal, but the synthesized method satisfies the lookup so `Standard.Unknown.Class.Method` never fires.

**It destroys the developer's own declaration.** `JsonSymbolTable::unserializeClassMembers()` keys members by lowercased name:

```php
$stmts["M" . strtolower($method->name)] = $method;
```

Augmented members are appended after the parsed ones, so on the way back out of the symbol table the synthesized `values()` overwrites a declared one, taking its modifiers with it. The synthesized entry was created with no flags, so it is non-static, and every legitimate static call to a declared `public static function values()` is reported as:

```
Attempt to call non-static method: SomeEnum::values statically
```

Worth noting `cases()` had the same missing-modifier problem and was fixed by adding `MODIFIER_STATIC` in 205512e. That was right for `cases()`, because `cases()` is a real language method. Adding the modifier to `values()` would remove the false positive too, but it would keep the invented method and therefore keep hiding undefined calls, which is why this PR removes it instead.

## Verification

Full index and analyze over a fixture covering four shapes, one call each:

| call | before | after |
|---|---|---|
| enum declares `public static function values()` | `Standard.Incorrect.Dynamic` (false positive) | clean |
| enum takes `values()` from a trait | `Standard.Incorrect.Dynamic` (false positive) | clean |
| enum declares no `values()` | `Standard.Incorrect.Dynamic` (wrong error) | `Standard.Unknown.Class.Method` (correct) |
| enum declares an instance `values()` | `Standard.Incorrect.Dynamic` (correct) | `Standard.Incorrect.Dynamic` (correct) |

Four findings, two of them wrong and one misattributed, become two correct ones.

## The tests fail without this change

Running the four new assertions against `master`'s augmenter, with nothing else altered:

| test | result on master | what it demonstrates |
|---|---|---|
| undeclared `values()` is an unknown method | expected 1, got 0 | the synthesized member satisfies the lookup and hides the real error |
| undeclared `values()` is not a dynamic-call error | expected 0, got 1 | the wrong error is emitted in its place |
| declared `public static values()` stays static | `false is true` | the synthesized member overwrote the declaration and its modifiers |
| a backed enum gains no `values()` of its own | a `ClassMethod` was found | the synthesis itself |

`Tests: 6, Assertions: 13, Failures: 4`. The two that pass either way are guards rather than proof: a declared instance `values()` staying an instance method, and `cases()`/`from()`/`tryFrom()` remaining present and static.

## Test plan

- [x] Full unit suite: 367 tests, no failures
- [x] `phpcs --standard=./.phpcs.xml` clean on `src/` and on the new test file
- [x] Guardrail indexes and analyzes itself with zero errors
- [x] Fixture run above, before and after

`JsonSymbolTableEnumTest` exercises `JsonSymbolTable` directly. The check-level suite runs on `InMemorySymbolTable` (`tests/TestConfig.php:41`), which keeps the parsed node and never round trips, so it cannot observe the overwrite. That divergence between the test harness and the production path is why this shipped unnoticed, and may be worth a look on its own.

The trait case is deliberately not covered at the check level. Trait importing runs only in the analyzing phase, so an enum retrieved from the symbol table never carries its trait methods, and `InMemorySymbolTable` has no `Grabber` fallback to supply them. It resolves correctly in a real run, where `JsonSymbolTable` does fall back to `Grabber`, as the fixture above shows.
